### PR TITLE
Fix atom string handling

### DIFF
--- a/swipl/src/atom.rs
+++ b/swipl/src/atom.rs
@@ -373,7 +373,7 @@ where
             term.term_ptr(),
             &mut len,
             &mut ptr,
-            (CVT_ATOM | REP_UTF8).try_into().unwrap(),
+            (CVT_ATOM | REP_UTF8 | BUF_DISCARDABLE).try_into().unwrap(),
         )
     };
 

--- a/swipl/src/functor.rs
+++ b/swipl/src/functor.rs
@@ -85,19 +85,7 @@ impl Functor {
     ///
     /// This will panic if no prolog engine is active on this thread.
     pub fn name_string(&self) -> String {
-        self.with_name(|n| n.name().to_string())
-    }
-
-    /// Retrieve the name of this functor as a &str, which is passed into the given function.
-    ///
-    /// This avoids unnecessary string copies.
-    ///
-    /// This will panic if no prolog engine is active on this thread.
-    pub fn with_name_string<F, R>(&self, func: F) -> R
-    where
-        F: Fn(&str) -> R,
-    {
-        self.with_name(|n| func(n.name()))
+        self.with_name(|n| n.name())
     }
 
     /// Retrieve the arity of this functor.
@@ -210,7 +198,6 @@ mod tests {
         assert_eq!("moocows", f.name_string());
         assert_eq!("moocows", f.name().name());
         f.with_name(|name| assert_eq!("moocows", name.name()));
-        f.with_name_string(|name| assert_eq!("moocows", name));
 
         assert_eq!(3, f.arity());
     }

--- a/swipl/src/module.rs
+++ b/swipl/src/module.rs
@@ -78,19 +78,7 @@ impl Module {
     ///
     /// This will panic if no prolog engine is active on this thread.
     pub fn name_string(&self) -> String {
-        self.with_name(|n| n.name().to_string())
-    }
-
-    /// Retrieve the name of this module as a &str, which is passed into the given function.
-    ///
-    /// This avoids unnecessary string copies.
-    ///
-    /// This will panic if no prolog engine is active on this thread.
-    pub fn with_name_string<F, R>(&self, func: F) -> R
-    where
-        F: Fn(&str) -> R,
-    {
-        self.with_name(|n| func(n.name()))
+        self.with_name(|n| n.name())
     }
 }
 

--- a/swipl/src/predicate.rs
+++ b/swipl/src/predicate.rs
@@ -93,19 +93,7 @@ impl Predicate {
     ///
     /// This will panic if no prolog engine is active on this thread.
     pub fn name_string(&self) -> String {
-        self.with_name(|n| n.name().to_string())
-    }
-
-    /// Retrieve the name of this predicate as a &str, which is passed into the given function.
-    ///
-    /// This avoids unnecessary string copies.
-    ///
-    /// This will panic if no prolog engine is active on this thread.
-    pub fn with_name_string<F, R>(&self, func: F) -> R
-    where
-        F: Fn(&str) -> R,
-    {
-        self.with_name(|n| func(n.name()))
+        self.with_name(|n| n.name())
     }
 
     /// Retrieve the arity of this predicate.

--- a/swipl/src/term.rs
+++ b/swipl/src/term.rs
@@ -297,7 +297,9 @@ impl<'a> Term<'a> {
                 self.term,
                 &mut len,
                 &mut ptr,
-                (CVT_STRING | REP_UTF8).try_into().unwrap(),
+                (CVT_STRING | REP_UTF8 | BUF_DISCARDABLE)
+                    .try_into()
+                    .unwrap(),
             )
         };
 
@@ -347,7 +349,7 @@ impl<'a> Term<'a> {
                 self.term,
                 &mut len,
                 &mut ptr,
-                (CVT_ATOM | REP_UTF8).try_into().unwrap(),
+                (CVT_ATOM | REP_UTF8 | BUF_DISCARDABLE).try_into().unwrap(),
             )
         };
 


### PR DESCRIPTION
Atom string handling was fundamentally broken, as it assumed that the underlying string format for atom names was UTF8, when in fact it's potentially latin-1, octet or any number of wide character encodings, with no clear way to figure out which encoding is actually being used.

This pull request changes atom name extraction by using a workaround involving a temporary term ref, since SWI-Prolog does have functions for retrieving UTF8 strings from terms, where it handles all the required conversions to do so internally.

Not ideal, but at least it's correct.