### PR TITLE
Fix crash bug in wrapped arc blobs

### DIFF
--- a/swipl-macros/src/blob.rs
+++ b/swipl-macros/src/blob.rs
@@ -209,11 +209,11 @@ pub fn wrapped_arc_blob_macro(item: proc_macro::TokenStream) -> proc_macro::Toke
         static #blob_definition_ident: std::sync::atomic::AtomicPtr<#crt::fli::PL_blob_t> = std::sync::atomic::AtomicPtr::new(std::ptr::null_mut());
 
         unsafe extern "C" fn #blob_acquire(a: #crt::fli::atom_t) {
-            #crt::blob::acquire_arc_blob::<#item_name>(a);
+            #crt::blob::acquire_arc_blob::<#inner_type_name>(a);
         }
 
         unsafe extern "C" fn #blob_release(a: #crt::fli::atom_t) -> std::os::raw::c_int {
-            #crt::blob::release_arc_blob::<#item_name>(a);
+            #crt::blob::release_arc_blob::<#inner_type_name>(a);
 
             1
         }

--- a/swipl/src/blob.rs
+++ b/swipl/src/blob.rs
@@ -338,7 +338,7 @@ pub unsafe fn unify_with_arc<T>(
 
     let result = fli::PL_unify_blob(
         term.term_ptr(),
-        Arc::as_ptr(arc) as *const T as *mut c_void,
+        Arc::as_ptr(arc) as *mut c_void,
         0,
         blob_definition as *const fli::PL_blob_t as *mut fli::PL_blob_t,
     );


### PR DESCRIPTION
Wrapped arc blobs had a mistake in their macro generation, which caused the acquire and release functions to interpret the data passed to prolog as the wrong type. This caused refcount manipulation to have undefined behavior.