### PR TITLE
expand cargo-swipl with two more commands

### DIFF
--- a/cargo-swipl/src/main.rs
+++ b/cargo-swipl/src/main.rs
@@ -3,11 +3,8 @@ use std::env;
 use std::process::Command;
 use swipl_info::*;
 
-fn subcmd(subcommand: &ArgMatches, cmd: &str) {
+fn set_library_path(command: &mut Command) {
     let info = get_swipl_info();
-
-    let cargo = env::var("CARGO").unwrap_or("cargo".to_owned());
-    let mut command = Command::new(cargo);
 
     if cfg!(target_os = "windows") {
         let path = env::var("PATH").unwrap_or("".to_owned());
@@ -20,6 +17,13 @@ fn subcmd(subcommand: &ArgMatches, cmd: &str) {
     }
 
     command.env("SWI_HOME_DIR", info.swi_home);
+}
+
+fn subcmd(subcommand: &ArgMatches, cmd: &str) {
+    let cargo = env::var("CARGO").unwrap_or("cargo".to_owned());
+    let mut command = Command::new(cargo);
+
+    set_library_path(&mut command);
 
     command.arg(cmd);
     if let Some(m) = subcommand.values_of("cmd") {
@@ -31,6 +35,47 @@ fn subcmd(subcommand: &ArgMatches, cmd: &str) {
 
     if let Some(code) = exit_status.code() {
         std::process::exit(code);
+    }
+}
+
+fn print_info() {
+    let info = get_swipl_info();
+
+    println!(
+        "version: {}\nswihome: {}\nlibrary path: {}",
+        info.version, info.swi_home, info.lib_dir
+    );
+}
+
+fn arbitrary_command(subcommand: &ArgMatches) {
+    if let Some(mut m) = subcommand.values_of("cmd") {
+        let first = m.next();
+        if first.is_none() {
+            eprintln!("Error: no subcommand given");
+            std::process::exit(1);
+        }
+        let command_name = first.unwrap();
+        let mut command = Command::new(&command_name);
+        set_library_path(&mut command);
+        let rest: Vec<_> = m.collect();
+        command.args(rest);
+
+        let exit_status = command
+            .spawn()
+            .unwrap_or_else(|e| {
+                eprintln!("cargo-swipl: {}: {}", command_name, e);
+                let code = e.raw_os_error();
+                std::process::exit(code.unwrap_or(1));
+            })
+            .wait()
+            .unwrap();
+
+        if let Some(code) = exit_status.code() {
+            std::process::exit(code);
+        }
+    } else {
+        eprintln!("Error: no subcommand given");
+        std::process::exit(1);
     }
 }
 
@@ -49,6 +94,17 @@ fn main() {
                 .setting(AppSettings::TrailingVarArg)
                 .setting(AppSettings::AllowLeadingHyphen)
                 .about("run tests with swi-prolog added to the load path")
+                .arg(Arg::from_usage("<cmd>... 'commands to run'").required(false)),
+        )
+        .subcommand(
+            SubCommand::with_name("info")
+                .about("print information about the swipl environment")
+        )
+        .subcommand(
+            SubCommand::with_name("env")
+                .setting(AppSettings::TrailingVarArg)
+                .setting(AppSettings::AllowLeadingHyphen)
+                .about("run an arbitrary command in an environment where the swipl library is added to the load path")
                 .arg(Arg::from_usage("<cmd>... 'commands to run'").required(false)),
         );
 
@@ -69,6 +125,10 @@ fn main() {
         subcmd(matches, "test");
     } else if let Some(matches) = matches.subcommand_matches("run") {
         subcmd(matches, "run");
+    } else if let Some(_matches) = matches.subcommand_matches("info") {
+        print_info();
+    } else if let Some(matches) = matches.subcommand_matches("env") {
+        arbitrary_command(matches);
     } else {
         panic!("unknown subcommand");
     }


### PR DESCRIPTION
This pull adds two commands to `cargo swipl`:
- info: this prints some basic info about the swipl environment on path
- env: this allows you to run an arbitrary command with the same context set up as the cargo commands (so LD_LIBRARY_PATH and SWI_HOME_DIR set appropriately).