### PR TITLE
ci: remove mac os DMG

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,9 +20,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         dmg: [no_dmg]
-        include:
-          - os: macos-latest
-            dmg: dmg
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,6 +20,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         dmg: [no_dmg]
+        #include:
+        #  - os: macos-latest
+        #    dmg: dmg
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
The Mac OS CI DMG broke without a clear reason. We should test it sometime but it does not have high priority for now