### PR TITLE
Small fix to support aarch64.

### DIFF
--- a/swipl/src/blob.rs
+++ b/swipl/src/blob.rs
@@ -260,7 +260,7 @@ pub fn create_blob_definition(
     let mut result = unsafe { std::mem::zeroed::<fli::PL_blob_t>() };
     result.magic = fli::PL_BLOB_MAGIC as usize;
     result.flags = flags as usize;
-    result.name = name.as_ptr() as *mut i8;
+    result.name = name.as_ptr() as *mut std::os::raw::c_char;
     result.acquire = acquire;
     result.release = release;
     result.compare = compare;

--- a/swipl/src/init.rs
+++ b/swipl/src/init.rs
@@ -107,9 +107,9 @@ fn initialize_internal(
     mut initialized: RwLockWriteGuard<Option<Engine>>,
 ) -> Option<EngineActivation<'static>> {
     // TOOD we just pick "rust-swipl" as a fake program name here. This seems to work fine. But what we should really do is pass along the actual argv[0].
-    let mut args: [*mut i8; 3] = [
-        ARG0.as_ptr() as *mut i8,
-        ARG1.as_ptr() as *mut i8,
+    let mut args: [*mut std::os::raw::c_char; 3] = [
+        ARG0.as_ptr() as *mut std::os::raw::c_char,
+        ARG1.as_ptr() as *mut std::os::raw::c_char,
         std::ptr::null_mut(),
     ];
     // unsafe justification: this initializes the swipl library and is idempotent

--- a/swipl/src/stream.rs
+++ b/swipl/src/stream.rs
@@ -103,7 +103,7 @@ unsafe fn write_to_prolog_stream(stream: *mut fli::IOSTREAM, buf: &[u8]) -> io::
         let mut write_buf = Vec::with_capacity(buf.len() + 1);
         write_buf.extend_from_slice(buf);
         write_buf.push(0);
-        let result = fli::Sfputs(write_buf.as_ptr() as *const i8, stream);
+        let result = fli::Sfputs(write_buf.as_ptr() as *const std::os::raw::c_char, stream);
         if result == fli::EOF {
             if fli::Sferror(stream) != 0 {
                 fli::Sclearerr(stream);

--- a/swipl/src/term/mod.rs
+++ b/swipl/src/term/mod.rs
@@ -992,7 +992,7 @@ term_putable! {
 
 unifiable! {
     (self: &[u8], term) => {
-        let result = unsafe { PL_unify_string_nchars(term.term_ptr(), self.len() as size_t, self.as_ptr() as *const i8) };
+        let result = unsafe { PL_unify_string_nchars(term.term_ptr(), self.len() as size_t, self.as_ptr() as *const std::os::raw::c_char) };
 
         result != 0
     }
@@ -1017,7 +1017,7 @@ term_getable! {
 
 term_putable! {
     (self: [u8], term) => {
-        unsafe { PL_put_string_nchars(term.term_ptr(), self.len() as size_t, self.as_ptr() as *const i8) };
+        unsafe { PL_put_string_nchars(term.term_ptr(), self.len() as size_t, self.as_ptr() as *const std::os::raw::c_char) };
     }
 
 }


### PR DESCRIPTION
Tests pass on both x86 and arm after the change.
To get tests and cargo-swipl to build nixos I also had to specify the link path like so
```
RUSTFLAGS="-L/nix/store/8qslsmfg3b6y35r2dmsycf65vpk8msma-swi-prolog-8.3.29/lib/"
RUSTDOCFLAGS="-L/nix/store/8qslsmfg3b6y35r2dmsycf65vpk8msma-swi-prolog-8.3.29/lib/"
```
but I expect on a regular system they will just work. 

I was able to patch this into terminusdb and everything appears to be working.