### PR TITLE
Atom serialization shortcut

### DIFF
--- a/swipl/src/term/de.rs
+++ b/swipl/src/term/de.rs
@@ -459,7 +459,7 @@ impl<'de, C: QueryableContextType> de::Deserializer<'de> for Deserializer<'de, C
                     Err(Error::ValueOutOfRange)
                 }
             }
-            None => Err(Error::ValueNotOfExpectedType("u64 (x)")),
+            None => Err(Error::ValueNotOfExpectedType("u64")),
         }
     }
     fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value>

--- a/tests/json/src/lib.rs
+++ b/tests/json/src/lib.rs
@@ -59,4 +59,18 @@ mod tests {
 
         assert_eq!(atom!("hello"), atom);
     }
+
+    #[test]
+    fn serialize_atom_to_json() {
+        let engine = Engine::new();
+        let activation = engine.activate();
+        let _context: Context<_> = activation.into();
+
+        let atom = atom!("hello");
+        let expected = json!("hello");
+
+        let json = serde_json::to_value(atom).unwrap();
+
+        assert_eq!(expected, json);
+    }
 }

--- a/tests/json/src/lib.rs
+++ b/tests/json/src/lib.rs
@@ -1,6 +1,5 @@
 #[cfg(test)]
 mod tests {
-    use serde::{Deserialize, Serialize};
     use serde_json::{self, json, Value};
     use std::io::{BufWriter, Write};
     use swipl::prelude::*;
@@ -46,5 +45,18 @@ mod tests {
         let s = std::str::from_utf8(&vec).unwrap();
 
         assert_eq!(r#"{"foo":"bar","baz":{"elts":[42,{"wow":"moo"},50]}}"#, s);
+    }
+
+    #[test]
+    fn deserialize_atom_from_json() {
+        let engine = Engine::new();
+        let activation = engine.activate();
+        let _context: Context<_> = activation.into();
+
+        let json = json!("hello");
+
+        let atom: Atom = serde_json::from_value(json).unwrap();
+
+        assert_eq!(atom!("hello"), atom);
     }
 }


### PR DESCRIPTION
serializing/deserializing atoms can be done faster if we know that the serializer/deserializer is working with swipl data, rather than some other arbitrary serializer/deserializer. In this case, putting an atom into a term, or getting an atom from a term, is just a matter of passing through the underlying `atom_t` and doing some refcounting.

Of course, that cannot work with arbitrary serialization backends though. We can't just arbitrarily take some json data and interpret certain things as atom_t's, which are effectively just pointers, as that would lead to all sorts of undefined behavior. Therefore, this shortcut cannot be the default.

This pull request uses thread-local variables to detect that we are serializing to, or deserializing from, swipl state, and only in those cases will we use pointer-based atom conversions. In all other cases, we use string-based conversions.