### PR TITLE
introduce get_arg_ex

### DIFF
--- a/swipl/src/result.rs
+++ b/swipl/src/result.rs
@@ -16,7 +16,7 @@ use crate::context::{Context, QueryableContextType};
 /// This is either a failure or an exception. In case of an exception,
 /// whowever returned the exception was also supposed to raise an
 /// exception on the context.
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum PrologError {
     #[error("prolog function failed")]
     Failure,


### PR DESCRIPTION
get_arg_ex will raise an exception if an argument can't be retrieved from a function. This could be because the functor doesn't have enough arguments, or because the type is not the expected type.