### PR TITLE
Upgrade bindgen and remove clippy warnings

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install SWI Prolog on Linux
         run: |
           sudo apt-add-repository ppa:swi-prolog/stable

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,6 +14,17 @@ env:
   RUST_BACKTRACE: full
 
 jobs:
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/clippy-check@v1
+        continue-on-error: true
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features
+
   build:
     strategy:
       fail-fast: false

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
+          args: --all-features -Dwarnings
 
   build:
     strategy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features -Dwarnings
+          args: --all-features -- -Dwarnings
 
   build:
     strategy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,28 @@ env:
   RUST_BACKTRACE: full
 
 jobs:
+  is_duplicate_run:
+    name: Duplicate run?
+    runs-on: ubuntu-latest
+
+    outputs:
+      duplicate_run: ${{ steps.check_skip.outputs.should_skip }}
+
+    steps:
+      - uses: fkirc/skip-duplicate-actions@master
+        id: check_skip
+        with:
+          # Skip a concurrent run triggered by a pull_request event if there is
+          # already a run triggered by a push event.
+          concurrent_skipping: same_content_newer
+          # Cancel runs from outdated commits.
+          cancel_others: 'true'
+          # Do not skip push events. They are used by the push_docker job.
+          do_not_skip: '["push", "workflow_dispatch", "schedule"]'
+
   clippy:
+    needs:
+      - is_duplicate_run
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -26,6 +47,8 @@ jobs:
           args: --all-features -- -Dwarnings
 
   build:
+    needs:
+      - is_duplicate_run
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,6 @@ jobs:
       - run: sudo apt update && sudo apt install software-properties-common -y
       - run: sudo apt-add-repository ppa:swi-prolog/stable -y && sudo apt update && sudo apt install swi-prolog-nox
       - uses: actions-rs/clippy-check@v1
-        continue-on-error: true
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,6 +36,8 @@ jobs:
   clippy:
     needs:
       - is_duplicate_run
+    if: |
+      needs.is_duplicate_run.outputs.duplicate_run == 'false'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -49,6 +51,8 @@ jobs:
   build:
     needs:
       - is_duplicate_run
+    if: |
+      needs.is_duplicate_run.outputs.duplicate_run == 'false'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-
+      - run: sudo apt update && sudo apt install software-properties-common -y
+      - run: sudo apt-add-repository ppa:swi-prolog/stable -y && sudo apt update && sudo apt install swi-prolog-nox
       - uses: actions-rs/clippy-check@v1
         continue-on-error: true
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: sudo apt update && sudo apt install software-properties-common -y
       - run: sudo apt-add-repository ppa:swi-prolog/stable -y && sudo apt update && sudo apt install swi-prolog-nox
       - uses: actions-rs/clippy-check@v1
@@ -37,7 +37,7 @@ jobs:
         #    dmg: dmg
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install SWI Prolog on Linux
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |

--- a/cargo-swipl/src/main.rs
+++ b/cargo-swipl/src/main.rs
@@ -7,11 +7,11 @@ fn set_library_path(command: &mut Command) {
     let info = get_swipl_info();
 
     if cfg!(target_os = "windows") {
-        let path = env::var("PATH").unwrap_or("".to_owned());
+        let path = env::var("PATH").unwrap_or_else(|_|"".to_owned());
         let path = format!("{};{}", info.lib_dir, path);
         command.env("PATH", path);
     } else {
-        let ld_library_path = env::var("LD_LIBRARY_PATH").unwrap_or("".to_owned());
+        let ld_library_path = env::var("LD_LIBRARY_PATH").unwrap_or_else(|_|"".to_owned());
         let ld_library_path = format!("{}:{}", info.lib_dir, ld_library_path);
         command.env("LD_LIBRARY_PATH", ld_library_path);
     }
@@ -20,7 +20,7 @@ fn set_library_path(command: &mut Command) {
 }
 
 fn subcmd(subcommand: &ArgMatches, cmd: &str) {
-    let cargo = env::var("CARGO").unwrap_or("cargo".to_owned());
+    let cargo = env::var("CARGO").unwrap_or_else(|_|"cargo".to_owned());
     let mut command = Command::new(cargo);
 
     set_library_path(&mut command);
@@ -55,7 +55,7 @@ fn arbitrary_command(subcommand: &ArgMatches) {
             std::process::exit(1);
         }
         let command_name = first.unwrap();
-        let mut command = Command::new(&command_name);
+        let mut command = Command::new(command_name);
         set_library_path(&mut command);
         let rest: Vec<_> = m.collect();
         command.args(rest);

--- a/examples/swipl-module-example/src/lib.rs
+++ b/examples/swipl-module-example/src/lib.rs
@@ -110,7 +110,7 @@ predicates! {
     semidet fn stream_write_hello(context, stream_term) {
         let mut stream: WritablePrologStream = stream_term.get()?;
 
-        context.try_or_die(write!(stream, "こんにちは! 🫡\n"))
+        context.try_or_die(writeln!(stream, "こんにちは! 🫡"))
     }
 }
 

--- a/swipl-fli/Cargo.toml
+++ b/swipl-fli/Cargo.toml
@@ -11,5 +11,5 @@ documentation = "https://terminusdb-labs.github.io/swipl-rs/swipl_fli/"
 
 [dependencies]
 [build-dependencies]
-bindgen = "0.59.0"
+bindgen = "0.63.0"
 swipl-info = {path = "../swipl-info", version = "0.3.2"}

--- a/swipl-fli/src/lib.rs
+++ b/swipl-fli/src/lib.rs
@@ -5,6 +5,7 @@
 #![allow(non_snake_case)]
 // TODO any function that uses u128 should be excluded
 #![allow(improper_ctypes)]
+#![allow(clippy::useless_transmute)]
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 

--- a/swipl-info/src/lib.rs
+++ b/swipl-info/src/lib.rs
@@ -58,13 +58,12 @@ pub fn get_swipl_info() -> SwiplInfo {
 
     let version: u32 = String::from_utf8_lossy(&output.stdout).parse().unwrap();
 
-    let build_env_command: &str;
-    if version >= 80504 {
+    let build_env_command = if version >= 80504 {
         // build_environment predicate moved and is now called somewhat differently
-        build_env_command = "use_module(library(build/tools)), build_tools:build_environment(Env, []), memberchk('SWIHOME'=Swihome, Env), memberchk('PACKSODIR'=Packsodir, Env), memberchk('CFLAGS'=Cflags, Env), memberchk('LDSOFLAGS'=Ldflags, Env), format('~s~n~s~n~s~n~s~n', [Swihome, Packsodir, Cflags, Ldflags])";
+        "use_module(library(build/tools)), build_tools:build_environment(Env, []), memberchk('SWIHOME'=Swihome, Env), memberchk('PACKSODIR'=Packsodir, Env), memberchk('CFLAGS'=Cflags, Env), memberchk('LDSOFLAGS'=Ldflags, Env), format('~s~n~s~n~s~n~s~n', [Swihome, Packsodir, Cflags, Ldflags])"
     } else {
-        build_env_command = "use_module(library(prolog_pack)), prolog_pack:build_environment(Env), memberchk('SWIHOME'=Swihome, Env), memberchk('PACKSODIR'=Packsodir, Env), memberchk('CFLAGS'=Cflags, Env), memberchk('LDSOFLAGS'=Ldflags, Env), format('~s~n~s~n~s~n~s~n', [Swihome, Packsodir, Cflags, Ldflags])";
-    }
+        "use_module(library(prolog_pack)), prolog_pack:build_environment(Env), memberchk('SWIHOME'=Swihome, Env), memberchk('PACKSODIR'=Packsodir, Env), memberchk('CFLAGS'=Cflags, Env), memberchk('LDSOFLAGS'=Ldflags, Env), format('~s~n~s~n~s~n~s~n', [Swihome, Packsodir, Cflags, Ldflags])"
+    };
 
     let output = Command::new(&swipl_path)
         .arg("-g")
@@ -101,12 +100,11 @@ pub fn get_swipl_info() -> SwiplInfo {
     let cflags = lines.next().unwrap().to_owned();
     let ldflags = lines.next().unwrap().to_owned();
 
-    let lib_name;
-    if cfg!(target_os = "windows") {
-        lib_name = "libswipl".to_string();
+    let lib_name = if cfg!(target_os = "windows") {
+        "libswipl".to_string()
     } else {
-        lib_name = "swipl".to_string();
-    }
+        "swipl".to_string()
+    };
 
     let header_dir = format!("{}/include", swi_home);
 

--- a/swipl-macros/src/atom.rs
+++ b/swipl-macros/src/atom.rs
@@ -1,4 +1,3 @@
-use proc_macro;
 use proc_macro2::Span;
 use quote::quote;
 use syn::parse::{Parse, ParseBuffer, Result};

--- a/swipl-macros/src/blob.rs
+++ b/swipl-macros/src/blob.rs
@@ -132,7 +132,7 @@ pub fn arc_blob_macro(
                     definition = #blob_definition_ident.load(std::sync::atomic::Ordering::Relaxed);
                 }
 
-                unsafe { std::mem::transmute(definition) }
+                unsafe { &*definition }
             }
         }
 
@@ -282,7 +282,7 @@ pub fn wrapped_arc_blob_macro(item: proc_macro::TokenStream) -> proc_macro::Toke
                     definition = #blob_definition_ident.load(std::sync::atomic::Ordering::Relaxed);
                 }
 
-                unsafe { std::mem::transmute(definition) }
+                unsafe { &*definition }
             }
         }
 
@@ -437,7 +437,7 @@ pub fn clone_blob_macro(
                     definition = #blob_definition_ident.load(std::sync::atomic::Ordering::Relaxed);
                 }
 
-                unsafe { std::mem::transmute(definition) }
+                unsafe { &*definition }
             }
         }
 

--- a/swipl-macros/src/blob.rs
+++ b/swipl-macros/src/blob.rs
@@ -1,7 +1,6 @@
 use crate::kw;
 use crate::util::*;
 
-use proc_macro;
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
 use syn::parse::{Parse, ParseStream, Result};
@@ -37,14 +36,13 @@ pub fn arc_blob_macro(
     let blob_compare = Ident::new(&format!("__{}_blob_compare", item_name), Span::call_site());
     let blob_write = Ident::new(&format!("__{}_blob_write", item_name), Span::call_site());
 
-    let default_implementation;
-    if attr_def.defaults {
-        default_implementation = quote! {
+    let default_implementation = if attr_def.defaults {
+        quote! {
             impl #crt::blob::ArcBlobImpl for #item_name {}
-        };
+        }
     } else {
-        default_implementation = quote! {};
-    }
+        quote! {}
+    };
 
     let result = quote! {
         #item_def
@@ -169,14 +167,13 @@ pub fn wrapped_arc_blob_macro(item: proc_macro::TokenStream) -> proc_macro::Toke
     let blob_compare = Ident::new(&format!("__{}_blob_compare", item_name), Span::call_site());
     let blob_write = Ident::new(&format!("__{}_blob_write", item_name), Span::call_site());
 
-    let default_implementation;
-    if item_def.defaults {
-        default_implementation = quote! {
+    let default_implementation = if item_def.defaults {
+        quote! {
             impl #crt::blob::WrappedArcBlobImpl for #item_name {}
-        };
+        }
     } else {
-        default_implementation = quote! {};
-    }
+        quote! {}
+    };
 
     let result = quote! {
         #visibility struct #item_name(#visibility Arc<#inner_type_name>);
@@ -348,14 +345,13 @@ pub fn clone_blob_macro(
     let blob_compare = Ident::new(&format!("__{}_blob_compare", item_name), Span::call_site());
     let blob_write = Ident::new(&format!("__{}_blob_write", item_name), Span::call_site());
 
-    let default_implementation;
-    if attr_def.defaults {
-        default_implementation = quote! {
+    let default_implementation = if attr_def.defaults {
+        quote! {
             impl #crt::blob::CloneBlobImpl for #item_name {}
-        };
+        }
     } else {
-        default_implementation = quote! {};
-    }
+        quote! {}
+    };
 
     let result = quote! {
         #item_def
@@ -484,12 +480,11 @@ pub fn wrapped_clone_blob_macro(item: proc_macro::TokenStream) -> proc_macro::To
     let visibility = &item_def.visibility;
     let inner_type_name = &item_def.inner_type;
 
-    let attr;
-    if item_def.defaults {
-        attr = quote! {#[clone_blob(#name_lit, defaults)]};
+    let attr = if item_def.defaults {
+        quote! {#[clone_blob(#name_lit, defaults)]}
     } else {
-        attr = quote! {#[clone_blob(#name_lit)]};
-    }
+        quote! {#[clone_blob(#name_lit)]}
+    };
 
     let result = quote! {
         #attr
@@ -517,14 +512,13 @@ impl Parse for ArcBlobAttr {
     fn parse(input: ParseStream) -> Result<Self> {
         let name = input.parse()?;
 
-        let defaults;
-        if input.peek(Token![,]) {
+        let defaults = if input.peek(Token![,]) {
             input.parse::<Token![,]>()?;
             input.parse::<kw::defaults>()?;
-            defaults = true;
+            true
         } else {
-            defaults = false;
-        }
+            false
+        };
 
         Ok(Self { name, defaults })
     }
@@ -583,14 +577,13 @@ impl Parse for WrappedArcBlobItem {
         input.parse::<Token![,]>()?;
         let inner_type = input.parse()?;
 
-        let defaults;
-        if input.peek(Token![,]) {
+        let defaults = if input.peek(Token![,]) {
             input.parse::<Token![,]>()?;
             input.parse::<kw::defaults>()?;
-            defaults = true;
+            true
         } else {
-            defaults = false;
-        }
+            false
+        };
 
         Ok(Self {
             visibility,

--- a/swipl-macros/src/blob.rs
+++ b/swipl-macros/src/blob.rs
@@ -53,18 +53,22 @@ pub fn arc_blob_macro(
             }
         }
 
+        #[allow(non_upper_case_globals)]
         static #blob_definition_ident: std::sync::atomic::AtomicPtr<#crt::fli::PL_blob_t> = std::sync::atomic::AtomicPtr::new(std::ptr::null_mut());
 
+        #[allow(non_snake_case)]
         unsafe extern "C" fn #blob_acquire(a: #crt::fli::atom_t) {
             #crt::blob::acquire_arc_blob::<#item_name>(a);
         }
 
+        #[allow(non_snake_case)]
         unsafe extern "C" fn #blob_release(a: #crt::fli::atom_t) -> std::os::raw::c_int {
             #crt::blob::release_arc_blob::<#item_name>(a);
 
             1
         }
 
+        #[allow(non_snake_case)]
         unsafe extern "C" fn #blob_compare(a: #crt::fli::atom_t, b: #crt::fli::atom_t)->std::os::raw::c_int {
             match #crt::context::prolog_catch_unwind(||{
                 let a_val = #crt::fli::PL_blob_data(a,
@@ -84,6 +88,7 @@ pub fn arc_blob_macro(
             }
         }
 
+        #[allow(non_snake_case)]
         unsafe extern "C" fn #blob_write(s: *mut #crt::fli::IOSTREAM,
                                          a: #crt::fli::atom_t,
                                          _flags: std::os::raw::c_int)
@@ -203,18 +208,22 @@ pub fn wrapped_arc_blob_macro(item: proc_macro::TokenStream) -> proc_macro::Toke
             }
         }
 
+        #[allow(non_upper_case_globals)]
         static #blob_definition_ident: std::sync::atomic::AtomicPtr<#crt::fli::PL_blob_t> = std::sync::atomic::AtomicPtr::new(std::ptr::null_mut());
 
+        #[allow(non_snake_case)]
         unsafe extern "C" fn #blob_acquire(a: #crt::fli::atom_t) {
             #crt::blob::acquire_arc_blob::<#inner_type_name>(a);
         }
 
+        #[allow(non_snake_case)]
         unsafe extern "C" fn #blob_release(a: #crt::fli::atom_t) -> std::os::raw::c_int {
             #crt::blob::release_arc_blob::<#inner_type_name>(a);
 
             1
         }
 
+        #[allow(non_snake_case)]
         unsafe extern "C" fn #blob_compare(a: #crt::fli::atom_t, b: #crt::fli::atom_t)->std::os::raw::c_int {
             match #crt::context::prolog_catch_unwind(||{
                 let a_val = #crt::fli::PL_blob_data(a,
@@ -234,6 +243,7 @@ pub fn wrapped_arc_blob_macro(item: proc_macro::TokenStream) -> proc_macro::Toke
             }
         }
 
+        #[allow(non_snake_case)]
         unsafe extern "C" fn #blob_write(s: *mut #crt::fli::IOSTREAM,
                                          a: #crt::fli::atom_t,
                                          _flags: std::os::raw::c_int)
@@ -362,14 +372,17 @@ pub fn clone_blob_macro(
             }
         }
 
+        #[allow(non_upper_case_globals)]
         static #blob_definition_ident: std::sync::atomic::AtomicPtr<#crt::fli::PL_blob_t> = std::sync::atomic::AtomicPtr::new(std::ptr::null_mut());
 
+        #[allow(non_snake_case)]
         unsafe extern "C" fn #blob_release(a: #crt::fli::atom_t) -> std::os::raw::c_int {
             #crt::blob::release_clone_blob::<#item_name>(a);
 
             1
         }
 
+        #[allow(non_snake_case)]
         unsafe extern "C" fn #blob_compare(a: #crt::fli::atom_t, b: #crt::fli::atom_t)->std::os::raw::c_int {
             match #crt::context::prolog_catch_unwind(|| {
                 let a_val = #crt::fli::PL_blob_data(a,
@@ -389,6 +402,7 @@ pub fn clone_blob_macro(
             }
         }
 
+        #[allow(non_snake_case)]
         unsafe extern "C" fn #blob_write(s: *mut #crt::fli::IOSTREAM,
                                          a: #crt::fli::atom_t,
                                          _flags: std::os::raw::c_int)

--- a/swipl-macros/src/functor.rs
+++ b/swipl-macros/src/functor.rs
@@ -1,4 +1,3 @@
-use proc_macro;
 use proc_macro2::Span;
 use quote::quote;
 use syn::parse::{Parse, ParseBuffer, Result};
@@ -52,7 +51,7 @@ impl Parse for Functor {
                         return Ok(Functor {
                             name: name.to_string(),
                             name_span: x.span(),
-                            arity: arity,
+                            arity,
                             arity_span: x.span(),
                         });
                     } else {

--- a/swipl-macros/src/lib.rs
+++ b/swipl-macros/src/lib.rs
@@ -46,7 +46,7 @@ use proc_macro::TokenStream;
 /// ```
 #[proc_macro]
 pub fn prolog(stream: TokenStream) -> TokenStream {
-    prolog::prolog_macro(stream).into()
+    prolog::prolog_macro(stream)
 }
 
 /// Generate an inline callable predicate.
@@ -69,7 +69,7 @@ pub fn prolog(stream: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro]
 pub fn pred(stream: TokenStream) -> TokenStream {
-    pred::pred_macro(stream).into()
+    pred::pred_macro(stream)
 }
 
 /// Define foreign predicates written in rust for use in prolog.
@@ -229,7 +229,7 @@ pub fn pred(stream: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro]
 pub fn predicates(stream: TokenStream) -> TokenStream {
-    predicate::predicates_macro(stream).into()
+    predicate::predicates_macro(stream)
 }
 
 /// Generate a term from a rust expression.
@@ -263,7 +263,7 @@ pub fn predicates(stream: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro]
 pub fn term(stream: TokenStream) -> TokenStream {
-    term::term_macro(stream).into()
+    term::term_macro(stream)
 }
 
 /// Define an arc blob.

--- a/swipl-macros/src/pred.rs
+++ b/swipl-macros/src/pred.rs
@@ -1,4 +1,3 @@
-use proc_macro;
 use proc_macro2::Span;
 use quote::quote;
 use syn::parse::{Parse, ParseBuffer, Result};
@@ -11,7 +10,7 @@ pub fn pred_macro(stream: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let definition = parse_macro_input!(stream as Pred);
     let arity = definition.arity as usize;
 
-    let name_lit = LitStr::new(&definition.name.to_string(), definition.name_span);
+    let name_lit = LitStr::new(&definition.name, definition.name_span);
     let module_lit = match definition.module {
         Some(m) => LitStr::new(&m.0, m.1),
         None => LitStr::new("", Span::call_site()),
@@ -83,7 +82,7 @@ impl Parse for Pred {
                     name = module_and_name.to_string();
                 }
 
-                if name.len() == 0 {
+                if name.is_empty() {
                     return Err(syn::parse::Error::new(x.span(), "invalid predicate name"));
                 }
 

--- a/swipl-macros/src/predicate.rs
+++ b/swipl-macros/src/predicate.rs
@@ -217,6 +217,7 @@ impl ForeignPredicateDefinitionImpl for SemidetForeignPredicateDefinition {
                         let mut terms: [std::mem::MaybeUninit<#crt::term::Term>;#known_arity] =
                             std::mem::MaybeUninit::uninit().assume_init();
 
+                        #[allow(clippy::reversed_empty_ranges)]
                         for i in 0..#known_arity {
                             let term_ref = context.wrap_term_ref(term+i);
                             terms[i] = std::mem::MaybeUninit::new(term_ref);
@@ -425,6 +426,7 @@ impl ForeignPredicateDefinitionImpl for NondetForeignPredicateDefinition {
                         let mut terms: [std::mem::MaybeUninit<#crt::term::Term>;#known_arity] =
                             std::mem::MaybeUninit::uninit().assume_init();
 
+                        #[allow(clippy::reversed_empty_ranges)]
                         for i in 0..#known_arity {
                             let term_ref = context.wrap_term_ref(term+i);
                             terms[i] = std::mem::MaybeUninit::new(term_ref);

--- a/swipl-macros/src/predicate.rs
+++ b/swipl-macros/src/predicate.rs
@@ -1,7 +1,6 @@
 use crate::kw;
 use crate::util::*;
 
-use proc_macro;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::parse::{Nothing, Parse, ParseStream, Result};
@@ -156,7 +155,7 @@ impl Parse for SemidetForeignPredicateDefinition {
             params_stream.parse_terminated(Ident::parse)?;
         let span = params_stream.span();
         let params: Vec<_> = params_punct.into_iter().collect();
-        if params.len() == 0 {
+        if params.is_empty() {
             return Err(syn::Error::new(
                 span,
                 "need at least one argument for query context",
@@ -321,7 +320,7 @@ impl Parse for NondetForeignPredicateDefinition {
             params_stream.parse_terminated(Ident::parse)?;
         let span = params_stream.span();
         let params: Vec<_> = params_punct.into_iter().collect();
-        if params.len() == 0 {
+        if params.is_empty() {
             return Err(syn::Error::new(
                 span,
                 "need at least one argument for query context",

--- a/swipl-macros/src/prolog.rs
+++ b/swipl-macros/src/prolog.rs
@@ -1,5 +1,4 @@
 use crate::util::*;
-use proc_macro;
 use proc_macro2::{self, Span, TokenStream};
 use quote::quote;
 use syn::parse::{Parse, ParseStream, Result};
@@ -13,8 +12,7 @@ pub fn prolog_macro(stream: proc_macro::TokenStream) -> proc_macro::TokenStream 
         .into_iter()
         .map(|p| p.into_definition());
     let gen = quote! {#(#definitions)*};
-    let result = gen.into();
-    result
+    gen.into()
 }
 
 struct PrologPredicate {

--- a/swipl-macros/src/term.rs
+++ b/swipl-macros/src/term.rs
@@ -1,4 +1,3 @@
-use proc_macro;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use std::collections::HashMap;
@@ -142,7 +141,7 @@ impl Leaf {
                 Self::Int(i) => {
                     // terrible, but necessary?
                     let int_str = format!("{}", i);
-                    if int_str.chars().next().unwrap() == '-' {
+                    if int_str.starts_with('-') {
                         quote! {#into.unify(#i as i64)?;}
                     } else {
                         quote! {#into.unify(#i as u64)?;}
@@ -437,12 +436,11 @@ impl Tuple {
         };
 
         let mut terms_chain = Vec::with_capacity(len);
-        for i in 0..(len - 1) {
+        for term_ident in term_idents.iter() {
             // for each element except the last one, we need to
             // - unify comma functor with current
             // - unify element with first
             // - make current the second element
-            let term_ident = &term_idents[i];
             terms_chain.push(quote! {
                 cur_ident.unify(&comma_functor)?;
                 cur_ident.unify_arg(1, &#term_ident)?;
@@ -478,7 +476,7 @@ impl Parse for Tuple {
         let terms_punct: Punctuated<Term, Token![,]> =
             terms_stream.parse_terminated(Term::parse)?;
         let terms: Vec<_> = terms_punct.into_iter().collect();
-        if terms.len() == 0 {
+        if terms.is_empty() {
             terms_stream
                 .error("parenthesized list of expressions should contain at least one element");
         }

--- a/swipl/src/atom.rs
+++ b/swipl/src/atom.rs
@@ -34,6 +34,11 @@ pub struct Atom {
 
 impl Atom {
     /// Wrap an `atom_t`, which is how the SWI-Prolog fli represents atoms.
+    ///
+    /// # Safety
+    /// This is unsafe because no check is done to ensure that the
+    /// atom_t indeed points at a valid atom. The caller will have to
+    /// ensure that this is the case.
     pub unsafe fn wrap(atom: atom_t) -> Atom {
         Atom { atom }
     }

--- a/swipl/src/atom.rs
+++ b/swipl/src/atom.rs
@@ -34,11 +34,6 @@ pub struct Atom {
 
 impl Atom {
     /// Wrap an `atom_t`, which is how the SWI-Prolog fli represents atoms.
-    ///
-    /// # Safety
-    /// This is unsafe because no check is done to ensure that the
-    /// atom_t indeed points at a valid atom. The caller will have to
-    /// ensure that this is the case.
     pub unsafe fn wrap(atom: atom_t) -> Atom {
         Atom { atom }
     }

--- a/swipl/src/blob.rs
+++ b/swipl/src/blob.rs
@@ -228,6 +228,7 @@ use crate::term::*;
 ///
 /// This is used by the various blob macros. You'll almost never have
 /// to use this directly.
+#[allow(clippy::too_many_arguments)]
 pub fn create_blob_definition(
     name: &'static [u8],
     text: bool,
@@ -314,6 +315,7 @@ pub trait ArcBlobImpl: ArcBlobBase + Send + Sync + Unpin {
 /// A blob type whose data is shared with SWI-Prolog as an atomic
 /// reference-counted pointer.
 ///
+/// # Safety
 /// This is unsafe because care has to be taken that the returned
 /// `PL_blob_t` from `get_blob_definition` actually matches the blob
 /// type.
@@ -325,10 +327,11 @@ pub unsafe trait ArcBlob: ArcBlobImpl {
 /// Unify the term with the given `Arc`, using the given blob
 /// definition to do so.
 ///
+/// This is used from the arc blob macros.
+///
+/// # Safety
 /// This is unsafe cause no attempt is made to ensure that the blob
 /// definition matches the given data.
-///
-/// This is used from the arc blob macros.
 pub unsafe fn unify_with_arc<T>(
     term: &Term,
     blob_definition: &'static fli::PL_blob_t,
@@ -349,10 +352,11 @@ pub unsafe fn unify_with_arc<T>(
 /// Unify the term with the given Cloneable, using the given blob
 /// definition to do so.
 ///
+/// This is used from the clone blob macros.
+///
+/// # Safety
 /// This is unsafe cause no attempt is made to ensure that the blob
 /// definition matches the given data.
-///
-/// This is used from the clone blob macros.
 pub unsafe fn unify_with_cloneable<T: Clone + Sized + Unpin>(
     term: &Term,
     blob_definition: &'static fli::PL_blob_t,
@@ -379,10 +383,11 @@ pub unsafe fn unify_with_cloneable<T: Clone + Sized + Unpin>(
 /// Retrieve an arc from the given term, using the given blob
 /// definition.
 ///
+/// This is used from the arc blob macros.
+///
+/// # Safety
 /// This is unsafe cause no attempt is made to ensure that the blob
 /// definition matches the given data.
-///
-/// This is used from the arc blob macros.
 pub unsafe fn get_arc_from_term<T>(
     term: &Term,
     blob_definition: &'static fli::PL_blob_t,
@@ -416,10 +421,11 @@ pub unsafe fn get_arc_from_term<T>(
 /// Retrieve a cloneable value from the given term, using the given
 /// blob definition.
 ///
+/// This is used from the clone blob macros.
+///
+/// # Safety
 /// This is unsafe cause no attempt is made to ensure that the blob
 /// definition matches the given data.
-///
-/// This is used from the clone blob macros.
 pub unsafe fn get_cloned_from_term<T: Clone + Sized + Unpin>(
     term: &Term,
     blob_definition: &'static fli::PL_blob_t,
@@ -451,10 +457,11 @@ pub unsafe fn get_cloned_from_term<T: Clone + Sized + Unpin>(
 
 /// Put an arc into the given term, using the given blob definition.
 ///
+/// This is used from the arc blob macros.
+///
+/// # Safety
 /// This is unsafe cause no attempt is made to ensure that the blob
 /// definition matches the given data.
-///
-/// This is used from the arc blob macros.
 pub unsafe fn put_arc_in_term<T>(
     term: &Term,
     blob_definition: &'static fli::PL_blob_t,
@@ -473,10 +480,11 @@ pub unsafe fn put_arc_in_term<T>(
 /// Put a Cloneable into the given term, using the given blob
 /// definition.
 ///
+/// This is used from the clone blob macros.
+///
+/// # Safety
 /// This is unsafe cause no attempt is made to ensure that the blob
 /// definition matches the given data.
-///
-/// This is used from the clone blob macros.
 pub unsafe fn put_cloneable_in_term<T: Clone + Sized + Unpin>(
     term: &Term,
     blob_definition: &'static fli::PL_blob_t,
@@ -499,6 +507,11 @@ pub unsafe fn put_cloneable_in_term<T: Clone + Sized + Unpin>(
 /// Increment the reference count on an Arc stored in a blob.
 ///
 /// This is used from the arc blob macros.
+///
+/// # Safety
+/// This is only safe to call from a thread with a swipl environment,
+/// on an atom which contains an arc blob of the given type.
+/// definition matches the given data.
 pub unsafe fn acquire_arc_blob<T>(atom: fli::atom_t) {
     let data = fli::PL_blob_data(atom, std::ptr::null_mut(), std::ptr::null_mut()) as *const T;
 
@@ -508,6 +521,10 @@ pub unsafe fn acquire_arc_blob<T>(atom: fli::atom_t) {
 /// Decrement the reference count on an Arc stored in a blob.
 ///
 /// This is used from the arc blob macros.
+///
+/// # Safety
+/// This is only safe to call from a thread with a swipl environment,
+/// on an atom which contains an arc blob of the given type.
 pub unsafe fn release_arc_blob<T>(atom: fli::atom_t) {
     let data = fli::PL_blob_data(atom, std::ptr::null_mut(), std::ptr::null_mut()) as *const T;
 
@@ -517,6 +534,10 @@ pub unsafe fn release_arc_blob<T>(atom: fli::atom_t) {
 /// Drop the rust value stored in a blob.
 ///
 /// This is used from the clone blob macros.
+///
+/// # Safety
+/// This is only safe to call from a thread with a swipl environment,
+/// on an atom which contains a clone blob of the given type.
 pub unsafe fn release_clone_blob<T>(atom: fli::atom_t) {
     let data =
         fli::PL_blob_data(atom, std::ptr::null_mut(), std::ptr::null_mut()) as *const T as *mut T;
@@ -603,6 +624,7 @@ pub trait WrappedArcBlobImpl: WrappedArcBlobBase {
 /// reference-counted pointer, and which is wrapped into a wrapper
 /// type.
 ///
+/// # Safety
 /// This is unsafe because care has to be taken that the returned
 /// `PL_blob_t` from `get_blob_definition` actually matches the blob
 /// type.
@@ -654,6 +676,7 @@ pub trait CloneBlobImpl: CloneBlobBase + Sized + Sync + Clone {
 /// A blob type whose data is copied into SWI-Prolog and dropped on
 /// garbage collection.
 ///
+/// # Safety
 /// This is unsafe because care has to be taken that the returned
 /// `PL_blob_t` from `get_blob_definition` actually matches the blob
 /// type.

--- a/swipl/src/blob.rs
+++ b/swipl/src/blob.rs
@@ -364,7 +364,7 @@ pub unsafe fn unify_with_cloneable<T: Clone + Sized + Unpin>(
     let result = fli::PL_unify_blob(
         term.term_ptr(),
         &cloned as *const T as *mut c_void,
-        std::mem::size_of::<T>() as fli::size_t,
+        std::mem::size_of::<T>(),
         blob_definition as *const fli::PL_blob_t as *mut fli::PL_blob_t,
     );
 
@@ -489,7 +489,7 @@ pub unsafe fn put_cloneable_in_term<T: Clone + Sized + Unpin>(
     fli::PL_put_blob(
         term.term_ptr(),
         &cloned as *const T as *mut c_void,
-        std::mem::size_of::<T>() as fli::size_t,
+        std::mem::size_of::<T>(),
         blob_definition as *const fli::PL_blob_t as *mut fli::PL_blob_t,
     );
 

--- a/swipl/src/dict.rs
+++ b/swipl/src/dict.rs
@@ -222,13 +222,7 @@ unsafe impl<'a> TermPutable for DictBuilder<'a> {
         };
 
         unsafe {
-            fli::PL_put_dict(
-                term.term_ptr(),
-                0,
-                len as fli::size_t,
-                key_atoms.as_ptr(),
-                value_terms,
-            );
+            fli::PL_put_dict(term.term_ptr(), 0, len, key_atoms.as_ptr(), value_terms);
 
             fli::PL_unify_arg(1, term.term_ptr(), tag_term.term_ptr());
 

--- a/swipl/src/dict.rs
+++ b/swipl/src/dict.rs
@@ -113,6 +113,12 @@ pub struct DictBuilder<'a> {
     entries: HashMap<Key, Option<Box<dyn TermPutable + 'a>>>,
 }
 
+impl<'a> Default for DictBuilder<'a> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'a> DictBuilder<'a> {
     /// Create a new dictionary builder.
     pub fn new() -> Self {

--- a/swipl/src/engine.rs
+++ b/swipl/src/engine.rs
@@ -57,6 +57,7 @@ const PL_ENGINE_CURRENT: PL_engine_t = 2 as PL_engine_t;
 
 /// Returns the current engine pointer.
 ///
+/// # Safety
 /// This is unsafe because behavior of this function is undefined if
 /// SWI-Prolog has not yet been activated.
 pub unsafe fn current_engine_ptr() -> PL_engine_t {
@@ -66,6 +67,12 @@ pub unsafe fn current_engine_ptr() -> PL_engine_t {
     PL_set_engine(PL_ENGINE_CURRENT, &mut current);
 
     current
+}
+
+impl Default for Engine {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl Engine {
@@ -110,11 +117,7 @@ impl Engine {
         // unsafe justification: swipl was shown to be initialized above so engine should be queryable
         let current = unsafe { current_engine_ptr() };
 
-        if current.is_null() {
-            false
-        } else {
-            true
-        }
+        !current.is_null()
     }
 
     /// Returns true if this engine is the engine currently active on this thread.

--- a/swipl/src/fli.rs
+++ b/swipl/src/fli.rs
@@ -2,6 +2,10 @@
 pub use swipl_fli::*;
 
 /// Retrieve the default exception.
+///
+/// # Safety
+/// This requires an initialized SWI-Prolog environment.
+#[allow(clippy::useless_transmute)]
 pub unsafe fn pl_default_exception() -> term_t {
     // So why this ugly transmute?
     // In swipl version 8.5.5, query handles change from being a

--- a/swipl/src/functor.rs
+++ b/swipl/src/functor.rs
@@ -26,6 +26,7 @@ pub struct Functor {
 impl Functor {
     /// Wrap a `functor_t`, which is how the SWI-Prolog fli represents functors.
     ///
+    /// # Safety
     /// This is unsafe because no check is done to ensure that the
     /// functor_t indeed points at a valid functor. The caller will
     /// have to ensure that this is the case.
@@ -176,9 +177,7 @@ impl LazyFunctor {
 
             functor
         } else {
-            let functor = unsafe { Functor::wrap(ptr as functor_t) };
-
-            functor
+            unsafe { Functor::wrap(ptr as functor_t) }
         }
     }
 }
@@ -210,8 +209,8 @@ mod tests {
 
         let f = Functor::new("moocows", 3);
         let term = context.new_term_ref();
-        assert!(term.unify(&f).is_ok());
-        assert!(term.unify(&f).is_ok());
+        assert!(term.unify(f).is_ok());
+        assert!(term.unify(f).is_ok());
     }
 
     #[test]
@@ -222,7 +221,7 @@ mod tests {
 
         let f = Functor::new("moocows", 3);
         let term = context.new_term_ref();
-        assert!(term.unify(&f).is_ok());
+        assert!(term.unify(f).is_ok());
     }
 
     #[test]
@@ -233,7 +232,7 @@ mod tests {
 
         let f1 = Functor::new("moocows", 3);
         let term = context.new_term_ref();
-        term.unify(&f1).unwrap();
+        term.unify(f1).unwrap();
         let f2: Functor = term.get().unwrap();
         assert_eq!(f1, f2);
     }
@@ -247,8 +246,8 @@ mod tests {
         let f1 = Functor::new("moocows", 3);
         let f2 = Functor::new("oinkpigs", 3);
         let term = context.new_term_ref();
-        assert!(term.unify(&f1).is_ok());
-        assert!(!term.unify(&f2).is_ok());
+        assert!(term.unify(f1).is_ok());
+        assert!(term.unify(f2).is_err());
     }
 
     #[test]
@@ -274,12 +273,12 @@ mod tests {
         assert!(term.unify_arg(1, 42_u64).is_ok());
         assert_eq!(42_u64, term.get_arg(1).unwrap());
         assert!(term.unify_arg(1, 42_u64).is_ok());
-        assert!(!term.unify_arg(1, 43_u64).is_ok());
+        assert!(term.unify_arg(1, 43_u64).is_err());
 
         assert!(term.unify_arg(2, 24_u64).is_ok());
         assert_eq!(24_u64, term.get_arg(2).unwrap());
 
-        assert!(!term.unify_arg(3, 24_u64).is_ok());
+        assert!(term.unify_arg(3, 24_u64).is_err());
         assert!(term.get_arg::<u64>(3).unwrap_err().is_failure());
     }
 

--- a/swipl/src/init.rs
+++ b/swipl/src/init.rs
@@ -40,8 +40,8 @@ pub fn assert_swipl_is_initialized() {
     }
 }
 
-static ARG0: &'static [u8] = b"rust-swipl\0"; // fake program name
-static ARG1: &'static [u8] = b"--quiet\0"; // suppress swipl banner printing
+static ARG0: &[u8] = b"rust-swipl\0"; // fake program name
+static ARG1: &[u8] = b"--quiet\0"; // suppress swipl banner printing
 
 /// Initialize SWI-Prolog.
 ///
@@ -159,6 +159,10 @@ pub fn reactivate_swipl() -> EngineActivation<'static> {
 ///
 /// This function is used by the `predicates!` macro to implement
 /// predicate registration.
+///
+/// # Safety
+/// This is only safe to call for functions which implement a foreign
+/// predicate.
 pub unsafe fn register_foreign_in_module(
     module: Option<&str>,
     name: &str,
@@ -202,8 +206,6 @@ pub unsafe fn register_foreign_in_module(
         arity as c_int,
         Some(converted_function_ptr),
         flags.try_into().unwrap(),
-        c_meta
-            .map(|m| m.as_ptr())
-            .unwrap_or_else(|| std::ptr::null()),
+        c_meta.map(|m| m.as_ptr()).unwrap_or_else(std::ptr::null),
     ) == 1
 }

--- a/swipl/src/init.rs
+++ b/swipl/src/init.rs
@@ -94,7 +94,7 @@ pub fn initialize_swipl_with_state(state: &'static [u8]) -> Option<EngineActivat
     // > to raise an exception.
     // - SWIPL FLI docs (footnote 208)
     // https://www.swi-prolog.org/pldoc/doc_for?object=c(%27PL_set_resource_db_mem%27)
-    let result = unsafe { PL_set_resource_db_mem(state.as_ptr(), state.len() as size_t) };
+    let result = unsafe { PL_set_resource_db_mem(state.as_ptr(), state.len()) };
 
     if result != TRUE as i32 {
         return None;

--- a/swipl/src/module.rs
+++ b/swipl/src/module.rs
@@ -25,6 +25,7 @@ unsafe impl Sync for Module {}
 impl Module {
     /// Wrap a `module_t`, which is how the SWI-Prolog fli represents modules.
     ///
+    /// # Safety
     /// This is unsafe because no check is done to ensure that the
     /// module_t indeed points at a valid module. The caller will have
     /// to ensure that this is the case.

--- a/swipl/src/predicate.rs
+++ b/swipl/src/predicate.rs
@@ -30,6 +30,7 @@ unsafe impl Sync for Predicate {}
 impl Predicate {
     /// Wrap a `predicate_t`, which is how the SWI-Prolog fli represents predicates.
     ///
+    /// # Safety
     /// This is unsafe because no check is done to ensure that the
     /// predicate_t indeed points at a valid predicate. The caller
     /// will have to ensure that this is the case.

--- a/swipl/src/record.rs
+++ b/swipl/src/record.rs
@@ -21,7 +21,7 @@ pub struct Record {
 
 impl Record {
     /// Extract a record from the given term.
-    pub fn from_term<'a>(term: &Term<'a>) -> Record {
+    pub fn from_term(term: &Term) -> Record {
         term.assert_term_handling_possible();
         unsafe {
             let record = fli::PL_record(term.term_ptr());
@@ -31,7 +31,7 @@ impl Record {
     }
 
     /// Copy the recorded term into the given term reference.
-    pub fn recorded<'a>(&self, term: &Term<'a>) -> PrologResult<()> {
+    pub fn recorded(&self, term: &Term) -> PrologResult<()> {
         term.assert_term_handling_possible();
         unsafe { into_prolog_result(fli::PL_recorded(self.record, term.term_ptr()) != 0) }
     }

--- a/swipl/src/result.rs
+++ b/swipl/src/result.rs
@@ -27,18 +27,12 @@ pub enum PrologError {
 impl PrologError {
     /// Returns true if this error is a failure.
     pub fn is_failure(&self) -> bool {
-        match self {
-            PrologError::Failure => true,
-            _ => false,
-        }
+        matches!(self, PrologError::Failure)
     }
 
     /// Returns true if this error is an exception.
     pub fn is_exception(&self) -> bool {
-        match self {
-            PrologError::Exception => true,
-            _ => false,
-        }
+        matches!(self, PrologError::Exception)
     }
 }
 
@@ -140,8 +134,8 @@ pub enum PrologStringError {
 
 pub type PrologStringResult<T> = Result<T, PrologStringError>;
 
-pub fn result_to_string_result<'a, C: QueryableContextType, T>(
-    c: &Context<'a, C>,
+pub fn result_to_string_result<C: QueryableContextType, T>(
+    c: &Context<C>,
     r: PrologResult<T>,
 ) -> PrologStringResult<T> {
     match r {
@@ -165,18 +159,19 @@ pub fn result_to_string_result<'a, C: QueryableContextType, T>(
                     "prolog had the following exception: {}",
                     s
                 ))),
-                Err(PrologError::Failure) => Err(PrologStringError::Exception(format!(
-                    "prolog failed while retrieving string from previous error"
-                ))),
-                Err(PrologError::Exception) => Err(PrologStringError::Exception(format!(
+                Err(PrologError::Failure) => Err(PrologStringError::Exception(
+                    "prolog failed while retrieving string from previous error".to_string(),
+                )),
+                Err(PrologError::Exception) => Err(PrologStringError::Exception(
                     "prolog threw exception while retrieving string from previous error"
-                ))),
+                        .to_string(),
+                )),
             }
         }
     }
 }
 
-pub fn unwrap_result<'a, C: QueryableContextType, T>(c: &Context<'a, C>, r: PrologResult<T>) -> T {
+pub fn unwrap_result<C: QueryableContextType, T>(c: &Context<C>, r: PrologResult<T>) -> T {
     match result_to_string_result(c, r) {
         Ok(r) => r,
         Err(PrologStringError::Failure) => panic!("prolog failed"),

--- a/swipl/src/stream.rs
+++ b/swipl/src/stream.rs
@@ -87,7 +87,7 @@ unsafe fn write_to_prolog_stream(stream: *mut fli::IOSTREAM, buf: &[u8]) -> io::
         count = fli::Sfwrite(
             buf.as_ptr() as *const std::ffi::c_void,
             1,
-            buf.len() as fli::size_t,
+            buf.len(),
             stream,
         ) as usize;
 
@@ -218,12 +218,7 @@ unsafe fn ensure_readable_prolog_stream(stream: *mut fli::IOSTREAM) -> io::Resul
 unsafe fn read_from_prolog_stream(stream: *mut fli::IOSTREAM, buf: &mut [u8]) -> io::Result<usize> {
     ensure_readable_prolog_stream(stream)?;
 
-    let count = fli::Sfread(
-        buf.as_ptr() as *mut std::ffi::c_void,
-        1,
-        buf.len() as fli::size_t,
-        stream,
-    ) as usize;
+    let count = fli::Sfread(buf.as_ptr() as *mut std::ffi::c_void, 1, buf.len(), stream) as usize;
 
     let error = fli::Sferror(stream);
     if error == -1 {

--- a/swipl/src/term/de.rs
+++ b/swipl/src/term/de.rs
@@ -478,9 +478,7 @@ impl<'de, C: QueryableContextType> de::Deserializer<'de> for Deserializer<'de, C
         match self.term.term_type() {
             TermType::Atom => {
                 let c = attempt_opt(self.term.get_atom_name(|a| {
-                    a?;
-
-                    let mut it = a.unwrap().chars();
+                    let mut it = a?.chars();
                     if let Some(c) = it.next() {
                         if it.next().is_none() {
                             return Some(c);

--- a/swipl/src/term/de.rs
+++ b/swipl/src/term/de.rs
@@ -7,8 +7,8 @@ use crate::text::*;
 use crate::{atom, functor};
 use serde::de::{self, DeserializeSeed, EnumAccess, MapAccess, SeqAccess, VariantAccess, Visitor};
 use serde::Deserialize;
-use std::fmt::{self, Display};
 use std::cell::Cell;
+use std::fmt::{self, Display};
 
 /// Deserialize a term into a rust value using serde.
 pub fn from_term<'a, C: QueryableContextType, T>(
@@ -392,13 +392,7 @@ impl<'de, C: QueryableContextType> de::Deserializer<'de> for Deserializer<'de, C
         V: Visitor<'de>,
     {
         match attempt_opt(self.term.get::<i64>())? {
-            Some(i) => {
-                if i >= i64::MIN as i64 && i <= i64::MAX as i64 {
-                    visitor.visit_i64(i as i64)
-                } else {
-                    Err(Error::ValueOutOfRange)
-                }
-            }
+            Some(i) => visitor.visit_i64(i),
             None => Err(Error::ValueNotOfExpectedType("i64")),
         }
     }
@@ -452,13 +446,7 @@ impl<'de, C: QueryableContextType> de::Deserializer<'de> for Deserializer<'de, C
         V: Visitor<'de>,
     {
         match attempt_opt(self.term.get::<u64>())? {
-            Some(i) => {
-                if i <= u64::MAX as u64 {
-                    visitor.visit_u64(i as u64)
-                } else {
-                    Err(Error::ValueOutOfRange)
-                }
-            }
+            Some(i) => visitor.visit_u64(i),
             None => Err(Error::ValueNotOfExpectedType("u64")),
         }
     }
@@ -490,9 +478,7 @@ impl<'de, C: QueryableContextType> de::Deserializer<'de> for Deserializer<'de, C
         match self.term.term_type() {
             TermType::Atom => {
                 let c = attempt_opt(self.term.get_atom_name(|a| {
-                    if a.is_none() {
-                        return None;
-                    }
+                    a?;
 
                     let mut it = a.unwrap().chars();
                     if let Some(c) = it.next() {
@@ -587,15 +573,13 @@ impl<'de, C: QueryableContextType> de::Deserializer<'de> for Deserializer<'de, C
                     Some(atom) => {
                         if cfg!(target_pointer_width = "32") {
                             visitor.visit_u32(atom.atom_ptr() as u32)
-                        }
-                        else {
+                        } else {
                             visitor.visit_u64(atom.atom_ptr() as u64)
                         }
-                    },
-                    None => Err(Error::ValueNotOfExpectedType("atom"))
+                    }
+                    None => Err(Error::ValueNotOfExpectedType("atom")),
                 }
-            }
-            else {
+            } else {
                 self.deserialize_string(visitor)
             }
         } else {
@@ -629,33 +613,31 @@ impl<'de, C: QueryableContextType> de::Deserializer<'de> for Deserializer<'de, C
                 context: self.context,
                 term: self.term,
             });
-        } else {
-            if let Some(mut terms) =
-                attempt_opt(self.context.compound_terms_vec_sized(&self.term, len))?
-            {
+        } else if let Some(mut terms) =
+            attempt_opt(self.context.compound_terms_vec_sized(&self.term, len))?
+        {
+            terms.reverse();
+            result = visitor.visit_seq(CompoundTermSeqAccess {
+                context: self.context,
+                terms,
+            });
+        } else if self.term.term_type() == TermType::ListPair
+            || self.term.term_type() == TermType::Nil
+        {
+            let mut terms = self.context.term_list_vec(&self.term);
+            if terms.len() != len {
+                result = Err(Error::ValueOutOfRange);
+            } else {
                 terms.reverse();
+
                 result = visitor.visit_seq(CompoundTermSeqAccess {
                     context: self.context,
                     terms,
                 });
-            } else if self.term.term_type() == TermType::ListPair
-                || self.term.term_type() == TermType::Nil
-            {
-                let mut terms = self.context.term_list_vec(&self.term);
-                if terms.len() != len {
-                    result = Err(Error::ValueOutOfRange);
-                } else {
-                    terms.reverse();
-
-                    result = visitor.visit_seq(CompoundTermSeqAccess {
-                        context: self.context,
-                        terms,
-                    });
-                }
-            } else {
-                result = Err(Error::ValueNotOfExpectedType("tuple"));
-            };
-        }
+            }
+        } else {
+            result = Err(Error::ValueNotOfExpectedType("tuple"));
+        };
 
         unsafe {
             cleanup_term.reset();
@@ -968,15 +950,13 @@ impl<'de> de::Deserializer<'de> for KeyDeserializer {
                     Key::Atom(atom) => {
                         if cfg!(target_pointer_width = "32") {
                             visitor.visit_u32(atom.atom_ptr() as u32)
-                        }
-                        else {
+                        } else {
                             visitor.visit_u64(atom.atom_ptr() as u64)
                         }
-                    },
-                    _ => Err(Error::ValueNotOfExpectedType("atom"))
+                    }
+                    _ => Err(Error::ValueNotOfExpectedType("atom")),
                 }
-            }
-            else {
+            } else {
                 self.deserialize_string(visitor)
             }
         } else {
@@ -1267,7 +1247,6 @@ impl DeserializingAtomState {
             da.set(true)
         });
 
-
         Self
     }
 
@@ -1302,6 +1281,7 @@ impl<'de> Visitor<'de> for AtomVisitor {
     }
 
     #[cfg(target_pointer_width = "32")]
+    #[allow(clippy::useless_conversion)]
     fn visit_u32<E>(self, v: u32) -> std::result::Result<Atom, E>
     where
         E: de::Error,
@@ -1315,6 +1295,7 @@ impl<'de> Visitor<'de> for AtomVisitor {
     }
 
     #[cfg(target_pointer_width = "64")]
+    #[allow(clippy::useless_conversion)]
     fn visit_u64<E>(self, v: u64) -> std::result::Result<Atom, E>
     where
         E: de::Error,

--- a/swipl/src/term/mod.rs
+++ b/swipl/src/term/mod.rs
@@ -142,6 +142,8 @@ impl<'a> Term<'a> {
     }
 
     /// Reset terms created after this term, including this term itself.
+    ///
+    /// # Safety
     /// Only safe to call when you're sure these terms aren't used afterwards.
     pub unsafe fn reset(&self) {
         self.assert_term_handling_possible();
@@ -354,14 +356,13 @@ impl<'a> Term<'a> {
         }
 
         let arg = unsafe { Term::new(arg_ref, self.origin.clone()) };
-        let result2;
-        if result != 0 {
-            result2 = arg.get_ex();
+        let result2 = if result != 0 {
+            arg.get_ex()
         } else {
             let context = unsafe { unmanaged_engine_context() };
             let exception_term = term! {context: error(arity_error, _)};
-            result2 = exception_term.and_then(|t| context.raise_exception(&t));
-        }
+            exception_term.and_then(|t| context.raise_exception(&t))
+        };
 
         unsafe { PL_reset_term_refs(arg_ref) };
 
@@ -384,9 +385,7 @@ impl<'a> Term<'a> {
                 self.term,
                 &mut len,
                 &mut ptr,
-                (CVT_STRING | REP_UTF8 | BUF_DISCARDABLE)
-                    .try_into()
-                    .unwrap(),
+                CVT_STRING | REP_UTF8 | BUF_DISCARDABLE,
             )
         };
 
@@ -397,8 +396,7 @@ impl<'a> Term<'a> {
         let arg = if result == 0 {
             None
         } else {
-            let swipl_string_ref =
-                unsafe { std::slice::from_raw_parts(ptr as *const u8, len as usize) };
+            let swipl_string_ref = unsafe { std::slice::from_raw_parts(ptr as *const u8, len) };
 
             let swipl_string = std::str::from_utf8(swipl_string_ref).unwrap();
 
@@ -436,7 +434,7 @@ impl<'a> Term<'a> {
                 self.term,
                 &mut len,
                 &mut ptr,
-                (CVT_ATOM | REP_UTF8 | BUF_DISCARDABLE).try_into().unwrap(),
+                CVT_ATOM | REP_UTF8 | BUF_DISCARDABLE,
             )
         };
 
@@ -447,8 +445,7 @@ impl<'a> Term<'a> {
         let arg = if result == 0 {
             None
         } else {
-            let swipl_string_ref =
-                unsafe { std::slice::from_raw_parts(ptr as *const u8, len as usize) };
+            let swipl_string_ref = unsafe { std::slice::from_raw_parts(ptr as *const u8, len) };
 
             let swipl_string = std::str::from_utf8(swipl_string_ref).unwrap();
 
@@ -523,13 +520,7 @@ impl<'a> PartialOrd for Term<'a> {
 
         let result = unsafe { PL_compare(self.term_ptr(), other.term_ptr()) };
 
-        Some(if result < 0 {
-            Ordering::Less
-        } else if result == 0 {
-            Ordering::Equal
-        } else {
-            Ordering::Greater
-        })
+        Some(result.cmp(&0))
     }
 }
 
@@ -571,6 +562,7 @@ impl<'a> TermOrigin<'a> {
 
 /// Trait for term unification.
 ///
+/// # Safety
 /// This is marked unsafe because in order to do term unification, we
 /// must be sure that
 /// - the term is created on the engine which is currently active
@@ -597,6 +589,7 @@ unsafe impl<T: Unifiable> Unifiable for &T {
 
 /// Trait for getting data from a term reference.
 ///
+/// # Safety
 /// This is marked unsafe because in order to do term getting, we
 /// must be sure that
 /// - the term is created on the engine which is currently active
@@ -624,6 +617,7 @@ pub unsafe trait TermGetable: Sized {
 /// entirely. This is a non-logical operation that doesn't play nice
 /// with backtracking. You're generally better off using unification.
 ///
+/// # Safety
 /// This is marked unsafe because in order to do term putting, we
 /// must be sure that
 /// - the term is created on the engine which is currently active
@@ -973,7 +967,7 @@ unifiable! {
         let result = unsafe { PL_unify_chars(
             term.term_ptr(),
             (PL_STRING | REP_UTF8).try_into().unwrap(),
-            self.len().try_into().unwrap(),
+            self.len(),
             self.as_bytes().as_ptr() as *const c_char,
         )
         };
@@ -987,7 +981,7 @@ unifiable! {
         let result = unsafe { PL_unify_chars(
             term.term_ptr(),
             (PL_STRING | REP_UTF8).try_into().unwrap(),
-            self.len().try_into().unwrap(),
+            self.len(),
             self.as_bytes().as_ptr() as *const c_char,
         )
         };
@@ -1011,7 +1005,7 @@ term_putable! {
         unsafe { PL_put_chars(
             term.term_ptr(),
             (PL_STRING | REP_UTF8).try_into().unwrap(),
-            self.len().try_into().unwrap(),
+            self.len(),
             self.as_bytes().as_ptr() as *const c_char,
         )
         };
@@ -1023,7 +1017,7 @@ term_putable! {
         unsafe { PL_put_chars(
             term.term_ptr(),
             (PL_STRING | REP_UTF8).try_into().unwrap(),
-            self.len().try_into().unwrap(),
+            self.len(),
             self.as_bytes().as_ptr() as *const c_char,
         )
         };
@@ -1047,8 +1041,8 @@ term_getable! {
             return None;
         }
 
-        let slice = unsafe { std::slice::from_raw_parts(string_ptr as *const u8, len as usize) };
-        let mut result: Vec<u8> = Vec::with_capacity(len as usize);
+        let slice = unsafe { std::slice::from_raw_parts(string_ptr as *const u8, len) };
+        let mut result: Vec<u8> = Vec::with_capacity(len);
         result.extend_from_slice(slice);
 
         Some(result)
@@ -1221,7 +1215,7 @@ mod tests {
         let term2 = context.new_term_ref();
         assert!(term1.unify(42_u64).is_ok());
         assert!(term2.unify(43_u64).is_ok());
-        assert!(!term1.unify(&term2).is_ok());
+        assert!(term1.unify(&term2).is_err());
     }
 
     #[test]
@@ -1232,7 +1226,7 @@ mod tests {
 
         let term = context.new_term_ref();
         assert!(term.unify(42_u64).is_ok());
-        assert!(!term.unify(43_u64).is_ok());
+        assert!(term.unify(43_u64).is_err());
     }
 
     #[test]
@@ -1257,10 +1251,10 @@ mod tests {
         let term1 = context.new_term_ref();
         assert!(term1.get::<bool>().unwrap_err().is_failure());
         term1.unify(true).unwrap();
-        assert_eq!(true, term1.get::<bool>().unwrap());
+        assert!(term1.get::<bool>().unwrap());
         let term2 = context.new_term_ref();
         term2.unify(false).unwrap();
-        assert_eq!(false, term2.get::<bool>().unwrap());
+        assert!(!term2.get::<bool>().unwrap());
     }
 
     #[test]
@@ -1510,7 +1504,7 @@ mod tests {
         let result: PrologResult<u64> = term.get_arg_ex(1);
         assert_eq!(PrologError::Exception, result.err().unwrap());
         assert!(context.has_exception());
-        context.with_exception(|e| println!("{}", context.string_from_term(&e.unwrap()).unwrap()));
+        context.with_exception(|e| println!("{}", context.string_from_term(e.unwrap()).unwrap()));
         context.with_exception(|e| e.unwrap().unify(&expected).unwrap());
     }
 

--- a/swipl/src/term/mod.rs
+++ b/swipl/src/term/mod.rs
@@ -1032,7 +1032,7 @@ term_putable! {
 
 unifiable! {
     (self: &[u8], term) => {
-        let result = unsafe { PL_unify_string_nchars(term.term_ptr(), self.len() as size_t, self.as_ptr() as *const std::os::raw::c_char) };
+        let result = unsafe { PL_unify_string_nchars(term.term_ptr(), self.len(), self.as_ptr() as *const std::os::raw::c_char) };
 
         result != 0
     }
@@ -1057,7 +1057,7 @@ term_getable! {
 
 term_putable! {
     (self: [u8], term) => {
-        unsafe { PL_put_string_nchars(term.term_ptr(), self.len() as size_t, self.as_ptr() as *const std::os::raw::c_char) };
+        unsafe { PL_put_string_nchars(term.term_ptr(), self.len(), self.as_ptr() as *const std::os::raw::c_char) };
     }
 
 }

--- a/swipl/src/text.rs
+++ b/swipl/src/text.rs
@@ -36,7 +36,7 @@ term_getable! {
         let mut s: *mut c_char = std::ptr::null_mut();
         let flags = fli::CVT_ATOM|fli::CVT_STRING|fli::BUF_DISCARDABLE|fli::REP_UTF8;
         let result = unsafe { fli::PL_get_nchars(term.term_ptr(),
-                                                 &mut len as *mut usize as *mut fli::size_t,
+                                                 &mut len as *mut usize,
                                                  &mut s,
                                                  flags) };
 


### PR DESCRIPTION
We were using an older version of bindgen which was generating code with loads of warnings in newer versions of rust. The new version generates better code, but also generates slightly different types which required various fixes.

As a bonus, all clippy warnings have been resolved too, including in macro expansions.