### PR TITLE
Type erased contexts

### DIFF
--- a/swipl/src/context.rs
+++ b/swipl/src/context.rs
@@ -604,6 +604,8 @@ prolog! {
     fn open_call(term);
 }
 
+pub type GenericQueryableContext<'a> = Context<'a, GenericQueryableContextType>;
+
 impl<'a, T: QueryableContextType> Context<'a, T> {
     /// Create a new Term reference in the current context.
     ///
@@ -1059,6 +1061,12 @@ impl<'a, T: QueryableContextType> Context<'a, T> {
             _ => Ok((head, tail)),
         }
     }
+
+    pub fn into_generic(&self) -> GenericQueryableContext {
+        self.assert_activated();
+        self.activated.set(false);
+        unsafe { Context::new_activated(self, GenericQueryableContextType, self.engine) }
+    }
 }
 
 /// An iterator over a term list.
@@ -1154,6 +1162,31 @@ pub unsafe fn prolog_catch_unwind<F: FnOnce() -> R + std::panic::UnwindSafe, R>(
         }
     }
 }
+
+/*
+unsafe impl ContextType for Box<dyn ContextType> {}
+unsafe impl ContextType for Box<dyn FrameableContextType> {}
+unsafe impl ContextType for Box<dyn QueryableContextType> {}
+impl FrameableContextType for Box<dyn FrameableContextType> {}
+impl FrameableContextType for Box<dyn QueryableContextType> {}
+impl QueryableContextType for Box<dyn QueryableContextType> {}
+
+pub struct ErasedQueryableContext {
+    inner: Context<'static, Box<dyn QueryableContextType>>,
+}
+
+impl ErasedQWueryableContext {
+    pub unsafe fn new<'a, C: ContextType>(context: Context<'a, C>) -> Self {
+        let inner: Box<dyn QueryableContextType> = Box::new(context.context);
+
+    }
+}
+ */
+
+pub struct GenericQueryableContextType;
+unsafe impl ContextType for GenericQueryableContextType {}
+impl FrameableContextType for GenericQueryableContextType {}
+impl QueryableContextType for GenericQueryableContextType {}
 
 #[cfg(test)]
 mod tests {

--- a/swipl/src/context.rs
+++ b/swipl/src/context.rs
@@ -1163,26 +1163,6 @@ pub unsafe fn prolog_catch_unwind<F: FnOnce() -> R + std::panic::UnwindSafe, R>(
     }
 }
 
-/*
-unsafe impl ContextType for Box<dyn ContextType> {}
-unsafe impl ContextType for Box<dyn FrameableContextType> {}
-unsafe impl ContextType for Box<dyn QueryableContextType> {}
-impl FrameableContextType for Box<dyn FrameableContextType> {}
-impl FrameableContextType for Box<dyn QueryableContextType> {}
-impl QueryableContextType for Box<dyn QueryableContextType> {}
-
-pub struct ErasedQueryableContext {
-    inner: Context<'static, Box<dyn QueryableContextType>>,
-}
-
-impl ErasedQWueryableContext {
-    pub unsafe fn new<'a, C: ContextType>(context: Context<'a, C>) -> Self {
-        let inner: Box<dyn QueryableContextType> = Box::new(context.context);
-
-    }
-}
- */
-
 #[derive(Clone)]
 pub struct GenericQueryableContextType;
 unsafe impl ContextType for GenericQueryableContextType {}

--- a/swipl/src/context.rs
+++ b/swipl/src/context.rs
@@ -1183,6 +1183,7 @@ impl ErasedQWueryableContext {
 }
  */
 
+#[derive(Clone)]
 pub struct GenericQueryableContextType;
 unsafe impl ContextType for GenericQueryableContextType {}
 impl FrameableContextType for GenericQueryableContextType {}

--- a/swipl/src/result.rs
+++ b/swipl/src/result.rs
@@ -143,11 +143,8 @@ pub fn result_to_string_result<C: QueryableContextType, T>(
         Err(PrologError::Failure) => Err(PrologStringError::Failure),
         Err(PrologError::Exception) => {
             let r = c.with_exception(|e| {
-                eprintln!("a");
                 let e = e.expect("prolog exception but no exception in prolog engine");
-                eprintln!("b");
                 let result = c.string_from_term(e);
-                eprintln!("c");
 
                 result
             });

--- a/swipl/src/result.rs
+++ b/swipl/src/result.rs
@@ -144,9 +144,7 @@ pub fn result_to_string_result<C: QueryableContextType, T>(
         Err(PrologError::Exception) => {
             let r = c.with_exception(|e| {
                 let e = e.expect("prolog exception but no exception in prolog engine");
-                let result = c.string_from_term(e);
-
-                result
+                c.string_from_term(e)
             });
 
             c.clear_exception();

--- a/swipl/src/term/ser.rs
+++ b/swipl/src/term/ser.rs
@@ -671,7 +671,6 @@ impl<'a, C: QueryableContextType> ser::SerializeTuple for SerializeTuple<'a, C> 
     {
         self.len -= 1;
         if self.len == 0 {
-            eprintln!("last item");
             // this is our last item, so just unify directly
             let inner_serializer = Serializer::new_with_config(
                 self.context,
@@ -680,7 +679,6 @@ impl<'a, C: QueryableContextType> ser::SerializeTuple for SerializeTuple<'a, C> 
             );
             value.serialize(inner_serializer)
         } else {
-            eprintln!("some item");
             attempt_unify(&self.term, functor!(",/2"))?;
             let [head, tail] = attempt_opt(self.context.compound_terms(&self.term))?
                 .expect("should have two terms");


### PR DESCRIPTION
This introduces a new context type `GenericQueryableContext<'a>` which is type-erased version of `QueryContext<'a, QueryableContextType>`. Normal queryable contexts can be turned into this generic version for cases where type annotations are unwanted.