### PR TITLE
Special stream decoding for latin1

### DIFF
--- a/swipl/Cargo.toml
+++ b/swipl/Cargo.toml
@@ -17,6 +17,8 @@ lazy_static = "1.4.0"
 thiserror = "1.0"
 serde = {version="1.0", optional=true}
 convert_case = "0.6"
+num_enum = "0.7.1"
+either = "1.9.0"
 
 [dev-dependencies]
 serde = {version="1.0", features=["derive"]}

--- a/swipl/src/stream.rs
+++ b/swipl/src/stream.rs
@@ -195,8 +195,25 @@ pub struct ReadablePrologStream<'a> {
     _x: PhantomData<&'a ()>,
 }
 
+#[cfg(not(windows))]
 #[derive(FromPrimitive)]
 #[repr(u32)]
+pub enum StreamEncoding {
+    #[default]
+    Unknown = 0,
+    Octet,
+    Ascii,
+    Latin1,
+    Ansi,
+    Utf8,
+    Utf16Be,
+    Utf16Le,
+    Wchar,
+}
+
+#[cfg(windows)]
+#[derive(FromPrimitive)]
+#[repr(i32)]
 pub enum StreamEncoding {
     #[default]
     Unknown = 0,

--- a/swipl/src/term/ser.rs
+++ b/swipl/src/term/ser.rs
@@ -74,6 +74,7 @@ fn attempt_unify<U: Unifiable>(term: &Term, v: U) -> Result<(), Error> {
 pub struct SerializerConfiguration {
     default_tag: Option<Atom>,
     tag_struct_dicts: bool,
+    unit_atom: Option<Atom>,
 }
 
 impl Default for SerializerConfiguration {
@@ -88,6 +89,7 @@ impl SerializerConfiguration {
         Self {
             default_tag: None,
             tag_struct_dicts: false,
+            unit_atom: None,
         }
     }
 
@@ -123,6 +125,15 @@ impl SerializerConfiguration {
     /// default tag is not set, the tag will remain a variable.
     pub fn tag_struct_dicts(mut self) -> Self {
         self.set_tag_struct_dicts();
+        self
+    }
+
+    pub fn set_unit_atom(&mut self, unit: Atom) {
+        self.unit_atom = Some(unit);
+    }
+
+    pub fn unit_atom(mut self, unit: Atom) -> Self {
+        self.set_unit_atom(unit);
         self
     }
 }
@@ -232,7 +243,11 @@ impl<'a, C: QueryableContextType> serde::Serializer for Serializer<'a, C> {
         }
     }
     fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
-        attempt_unify(&self.term, Nil)
+        if let Some(unit) = self.configuration.unit_atom {
+            attempt_unify(&self.term, unit)
+        } else {
+            attempt_unify(&self.term, Nil)
+        }
     }
     fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok, Self::Error> {
         attempt_unify(&self.term, Atom::new(name))


### PR DESCRIPTION
prolog streams can have various encodings, but often we'd like readers to pretend that the underlying data is utf-8. This comes up especially for so-called 'latin-1' encoded streams, as prolog will try to pack strings that can fit into this encoding into this format, meaning streams over such strings are not valid utf-8.

This introduces a wrapper reader which processes an underlying reader (such as a prolog stream) and re-encodes the latin-1 data as utf-8.