### PR TITLE
swipl 9.1.19 compatibility: PL_new_term_refs takes size_t

### DIFF
--- a/swipl/src/callable.rs
+++ b/swipl/src/callable.rs
@@ -304,7 +304,7 @@ impl<const N: usize> Callable<N> for CallablePredicate<N> {
             .unwrap_or(std::ptr::null_mut());
         let flags = PL_Q_NORMAL | PL_Q_CATCH_EXCEPTION | PL_Q_EXT_STATUS;
         unsafe {
-            let terms = PL_new_term_refs(N as i32);
+            let terms = PL_new_term_refs(N);
             for (i, arg) in args.iter().enumerate() {
                 let term = context.wrap_term_ref(terms + i);
                 assert!(term.unify(arg).is_ok());

--- a/swipl/src/context.rs
+++ b/swipl/src/context.rs
@@ -625,12 +625,7 @@ impl<'a, T: QueryableContextType> Context<'a, T> {
     /// reference, ensuring that it cannot outlive the context that
     /// created it.
     pub fn new_term_refs<const N: usize>(&self) -> [Term; N] {
-        // TODO: this should be a compile time thing ideally
-        if N > i32::MAX as usize {
-            panic!("too many term refs requested: {}", N);
-        }
-
-        let mut term_ptr = unsafe { PL_new_term_refs(N as i32) };
+        let mut term_ptr = unsafe { PL_new_term_refs(N) };
         let mut result: [MaybeUninit<Term>; N] = unsafe { MaybeUninit::uninit().assume_init() };
         for r in result.iter_mut() {
             let term = unsafe { Term::new(term_ptr, self.as_term_origin()) };
@@ -657,11 +652,7 @@ impl<'a, T: QueryableContextType> Context<'a, T> {
     /// reference, ensuring that it cannot outlive the context that
     /// created it.
     pub fn new_term_refs_vec(&self, count: usize) -> Vec<Term> {
-        if count > i32::MAX as usize {
-            panic!("too many term refs requested: {}", count);
-        }
-
-        let mut term_ptr = unsafe { PL_new_term_refs(count as i32) };
+        let mut term_ptr = unsafe { PL_new_term_refs(count) };
         let mut result = Vec::with_capacity(count);
         for _ in 0..count {
             let term = unsafe { Term::new(term_ptr, self.as_term_origin()) };

--- a/swipl/src/dict.rs
+++ b/swipl/src/dict.rs
@@ -206,8 +206,7 @@ unsafe impl<'a> TermPutable for DictBuilder<'a> {
 
         let tag_term = context.new_term_ref();
         let len = self.entries.len();
-        // TODO assert len is not too big
-        let value_terms = unsafe { fli::PL_new_term_refs(len as i32) };
+        let value_terms = unsafe { fli::PL_new_term_refs(len) };
         let mut value_term = value_terms;
         let mut key_atoms = Vec::with_capacity(len);
 


### PR DESCRIPTION
As title; the prototype of this function changed in 9.1.19 [1]

Not sure if it's acceptable to bump the needed version of swipl like this or if we want some kind of magic to work with older headers too...

[1] https://swi-prolog.discourse.group/t/ann-swi-prolog-9-1-19/6978