### PR TITLE
SWI-Prolog 10 compatibility

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,10 +43,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo apt update && sudo apt install software-properties-common -y
       - run: sudo apt-add-repository ppa:swi-prolog/stable -y && sudo apt update && sudo apt install swi-prolog-nox
-      - uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features -- -Dwarnings
+      - run: cargo clippy --all-features -- -Dwarnings
 
   build:
     needs:

--- a/examples/swipl-module-example/src/lib.rs
+++ b/examples/swipl-module-example/src/lib.rs
@@ -101,7 +101,7 @@ predicates! {
     semidet fn unify_with_wrapped_blob(_context, term, num_term) {
         let num: u64 = num_term.get()?;
         let arc = Arc::new(Inner { num });
-        term.unify(&MooMoo(arc))
+        term.unify(MooMoo(arc))
     }
 
     semidet fn moomoo_num(_context, moo_term, num_term) {

--- a/swipl-fli/Cargo.toml
+++ b/swipl-fli/Cargo.toml
@@ -9,6 +9,12 @@ description = "Low-level bindings to the SWI-Prolog Foreign Language Interface"
 repository = "https://github.com/terminusdb-labs/swipl-rs/"
 documentation = "https://terminusdb-labs.github.io/swipl-rs/swipl_fli/"
 
+[features]
+default = []
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(swipl10)"] }
+
 [dependencies]
 [build-dependencies]
 bindgen = "0.69.4"

--- a/swipl-fli/build.rs
+++ b/swipl-fli/build.rs
@@ -10,6 +10,12 @@ fn main() {
     println!("cargo:rerun-if-changed=c/wrapper.h");
     println!("cargo:rerun-if-env-changed=SWIPL");
 
+    // Autodetect SWI-Prolog 10.x (version >= 100000)
+    // SWI-Prolog 10.x uses C11 bool for FLI return types
+    if info.version >= 100000 {
+        println!("cargo:rustc-cfg=swipl10");
+    }
+
     let bindings = bindgen::Builder::default()
         .header("c/wrapper.h")
         .clang_arg(format!("-I{}", info.header_dir))

--- a/swipl-fli/src/lib.rs
+++ b/swipl-fli/src/lib.rs
@@ -25,6 +25,7 @@ pub type FliResult = ::std::os::raw::c_int;
 ///
 /// This provides a portable way to check if an FLI function succeeded,
 /// regardless of whether it returns `c_int` (swipl 9.x) or `bool` (swipl 10.x).
+#[allow(clippy::wrong_self_convention)]
 pub trait FliSuccess {
     /// Returns `true` if the FLI call succeeded.
     fn is_success(self) -> bool;

--- a/swipl-macros/src/blob.rs
+++ b/swipl-macros/src/blob.rs
@@ -18,7 +18,7 @@ pub fn arc_blob_macro(
 
     let name_lit = attr_def.name;
     let name = name_lit.value();
-    let mut name_bytes = Vec::with_capacity(name.as_bytes().len() + 1);
+    let mut name_bytes = Vec::with_capacity(name.len() + 1);
     name_bytes.extend_from_slice(name.as_bytes());
     name_bytes.push(0);
     let name_bytes_lit = LitByteStr::new(&name_bytes, Span::call_site());
@@ -153,7 +153,7 @@ pub fn wrapped_arc_blob_macro(item: proc_macro::TokenStream) -> proc_macro::Toke
     let item_def = parse_macro_input!(item as WrappedArcBlobItem);
     let name_lit = item_def.name;
     let name = name_lit.value();
-    let mut name_bytes = Vec::with_capacity(name.as_bytes().len() + 1);
+    let mut name_bytes = Vec::with_capacity(name.len() + 1);
     name_bytes.extend_from_slice(name.as_bytes());
     name_bytes.push(0);
     let name_bytes_lit = LitByteStr::new(&name_bytes, Span::call_site());
@@ -338,7 +338,7 @@ pub fn clone_blob_macro(
 
     let name_lit = attr_def.name;
     let name = name_lit.value();
-    let mut name_bytes = Vec::with_capacity(name.as_bytes().len() + 1);
+    let mut name_bytes = Vec::with_capacity(name.len() + 1);
     name_bytes.extend_from_slice(name.as_bytes());
     name_bytes.push(0);
     let name_bytes_lit = LitByteStr::new(&name_bytes, Span::call_site());

--- a/swipl-macros/src/lib.rs
+++ b/swipl-macros/src/lib.rs
@@ -177,10 +177,10 @@ pub fn pred(stream: TokenStream) -> TokenStream {
 /// You can return from this block in three ways:
 /// - Return an exception or failure. The predicate will error or fail accordingly and the call block will not be invoked.
 /// - Return `None`. The call block will also not be invoked, but the
-/// predicate will return success. This is useful to handle predicate
-/// inputs which allow your predicate to behave in a semidet manner.
+///   predicate will return success. This is useful to handle predicate
+///   inputs which allow your predicate to behave in a semidet manner.
 /// - Return `Some(object)`. This returns a state object for use in
-/// the call block. After this, the call block will be invoked.
+///   the call block. After this, the call block will be invoked.
 ///
 /// ## Call
 /// The call block is called each time the next result is required from this predicate. This happens on the first call to this predicate (except if the setup returned early as described above), and subsequently upon backtracking. The call block is given a mutable borrow of the state object, and is therefore able to both inspect and modify it.

--- a/swipl-macros/src/predicate.rs
+++ b/swipl-macros/src/predicate.rs
@@ -74,6 +74,7 @@ impl Parse for AttributedForeignPredicateDefinition {
     }
 }
 
+#[allow(dead_code)]
 trait ForeignPredicateDefinitionImpl {
     fn generate_definition(&self) -> TokenStream;
     fn generate_trampoline(&self) -> (Ident, TokenStream);

--- a/swipl/Cargo.toml
+++ b/swipl/Cargo.toml
@@ -20,5 +20,9 @@ convert_case = "0.6"
 num_enum = "0.7.1"
 either = "1.9.0"
 
+[features]
+default = []
+gc_debug = []  # Enable GC debugging instrumentation
+
 [dev-dependencies]
 serde = {version="1.0", features=["derive"]}

--- a/swipl/src/atom.rs
+++ b/swipl/src/atom.rs
@@ -116,9 +116,9 @@ impl Atom {
     }
 }
 
-impl ToString for Atom {
-    fn to_string(&self) -> String {
-        self.name()
+impl std::fmt::Display for Atom {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name())
     }
 }
 
@@ -187,11 +187,7 @@ where
 
 term_getable! {
     (Atom, "atom", term) => {
-        match term.get_atom(|a| a.cloned()) {
-            Ok(r) => r,
-            // ignore this error - it'll be picked up again by the wrapper
-            Err(_) => None
-        }
+        term.get_atom(|a| a.cloned()).unwrap_or_default()
     }
 }
 
@@ -208,7 +204,7 @@ pub enum Atomable<'a> {
 }
 
 impl<'a> From<&'a str> for Atomable<'a> {
-    fn from(s: &str) -> Atomable {
+    fn from(s: &str) -> Atomable<'_> {
         Atomable::Str(s)
     }
 }
@@ -277,7 +273,7 @@ impl<'a> IntoAtom for Atomable<'a> {
     }
 }
 
-impl<'a> IntoAtom for &'a str {
+impl IntoAtom for &str {
     fn into_atom(self) -> Atom {
         Atom::new(self)
     }
@@ -330,7 +326,7 @@ impl<'a> AsAtom for Atomable<'a> {
     }
 }
 
-impl<'a> AsAtom for &'a str {
+impl AsAtom for &str {
     fn as_atom(&self) -> Atom {
         self.into_atom()
     }
@@ -404,11 +400,7 @@ where
 
 term_getable! {
     (Atomable<'static>, "atom", term) => {
-        match get_atomable(term, |a|a.map(|a|a.owned())) {
-            Ok(r) => r,
-            // ignore error - it'll be picked up in the wrapper
-            Err(_) => None
-        }
+        get_atomable(term, |a|a.map(|a|a.owned())).unwrap_or_default()
     }
 }
 

--- a/swipl/src/atom.rs
+++ b/swipl/src/atom.rs
@@ -15,6 +15,7 @@
 use super::context::*;
 use super::engine::*;
 use super::fli::*;
+use super::fli::FliSuccess;
 use super::init::*;
 use super::result::*;
 use super::term::*;
@@ -148,7 +149,7 @@ unifiable! {
     (self:Atom, term) => {
         let result = unsafe { PL_unify_atom(term.term_ptr(), self.atom) };
 
-        (result as i32) != 0
+        result.is_success()
     }
 }
 
@@ -169,7 +170,7 @@ where
         return Err(PrologError::Exception);
     }
 
-    let arg = if (result as i32) == 0 {
+    let arg = if !result.is_success() {
         None
     } else {
         let atom = unsafe { Atom::wrap(atom) };
@@ -352,7 +353,7 @@ unifiable! {
             )
         };
 
-        (result as i32) != 0
+        result.is_success()
     }
 }
 
@@ -383,7 +384,7 @@ where
         return Err(PrologError::Exception);
     }
 
-    let arg = if (result as i32) == 0 {
+    let arg = if !result.is_success() {
         None
     } else {
         let swipl_string_ref = unsafe { std::slice::from_raw_parts(ptr as *const u8, len) };

--- a/swipl/src/atom.rs
+++ b/swipl/src/atom.rs
@@ -148,7 +148,7 @@ unifiable! {
     (self:Atom, term) => {
         let result = unsafe { PL_unify_atom(term.term_ptr(), self.atom) };
 
-        result != 0
+        (result as i32) != 0
     }
 }
 
@@ -169,7 +169,7 @@ where
         return Err(PrologError::Exception);
     }
 
-    let arg = if result == 0 {
+    let arg = if (result as i32) == 0 {
         None
     } else {
         let atom = unsafe { Atom::wrap(atom) };
@@ -352,7 +352,7 @@ unifiable! {
             )
         };
 
-        result != 0
+        (result as i32) != 0
     }
 }
 
@@ -383,7 +383,7 @@ where
         return Err(PrologError::Exception);
     }
 
-    let arg = if result == 0 {
+    let arg = if (result as i32) == 0 {
         None
     } else {
         let swipl_string_ref = unsafe { std::slice::from_raw_parts(ptr as *const u8, len) };

--- a/swipl/src/blob.rs
+++ b/swipl/src/blob.rs
@@ -397,7 +397,7 @@ pub unsafe fn get_arc_from_term<T>(
 
     let mut blob_type = std::ptr::null_mut();
     if !fli::PL_is_blob(term.term_ptr(), &mut blob_type).is_success()
-        || blob_definition as *const fli::PL_blob_t != blob_type
+        || !std::ptr::eq(blob_definition as *const fli::PL_blob_t, blob_type)
     {
         return None;
     }
@@ -435,7 +435,7 @@ pub unsafe fn get_cloned_from_term<T: Clone + Sized + Unpin>(
 
     let mut blob_type = std::ptr::null_mut();
     if !fli::PL_is_blob(term.term_ptr(), &mut blob_type).is_success()
-        || blob_definition as *const fli::PL_blob_t != blob_type
+        || !std::ptr::eq(blob_definition as *const fli::PL_blob_t, blob_type)
     {
         return None;
     }

--- a/swipl/src/blob.rs
+++ b/swipl/src/blob.rs
@@ -220,6 +220,7 @@ use std::os::raw::{c_int, c_void};
 use std::sync::Arc;
 
 use crate::fli;
+use crate::fli::FliSuccess;
 use crate::stream::*;
 use crate::term::*;
 
@@ -346,7 +347,7 @@ pub unsafe fn unify_with_arc<T>(
         blob_definition as *const fli::PL_blob_t as *mut fli::PL_blob_t,
     );
 
-    (result as i32) != 0
+    result.is_success()
 }
 
 /// Unify the term with the given Cloneable, using the given blob
@@ -372,7 +373,7 @@ pub unsafe fn unify_with_cloneable<T: Clone + Sized + Unpin>(
         blob_definition as *const fli::PL_blob_t as *mut fli::PL_blob_t,
     );
 
-    if (result as i32) != 0 {
+    if result.is_success() {
         std::mem::forget(cloned);
         true
     } else {
@@ -395,7 +396,7 @@ pub unsafe fn get_arc_from_term<T>(
     term.assert_term_handling_possible();
 
     let mut blob_type = std::ptr::null_mut();
-    if (fli::PL_is_blob(term.term_ptr(), &mut blob_type) as i32) == 0
+    if !fli::PL_is_blob(term.term_ptr(), &mut blob_type).is_success()
         || blob_definition as *const fli::PL_blob_t != blob_type
     {
         return None;
@@ -409,7 +410,7 @@ pub unsafe fn get_arc_from_term<T>(
         std::ptr::null_mut(),
     );
 
-    if (result as i32) == 0 {
+    if !result.is_success() {
         None
     } else {
         Arc::increment_strong_count(data);
@@ -433,7 +434,7 @@ pub unsafe fn get_cloned_from_term<T: Clone + Sized + Unpin>(
     term.assert_term_handling_possible();
 
     let mut blob_type = std::ptr::null_mut();
-    if (fli::PL_is_blob(term.term_ptr(), &mut blob_type) as i32) == 0
+    if !fli::PL_is_blob(term.term_ptr(), &mut blob_type).is_success()
         || blob_definition as *const fli::PL_blob_t != blob_type
     {
         return None;
@@ -447,7 +448,7 @@ pub unsafe fn get_cloned_from_term<T: Clone + Sized + Unpin>(
         std::ptr::null_mut(),
     );
 
-    if (result as i32) == 0 {
+    if !result.is_success() {
         None
     } else {
         let cloned = (*data).clone();

--- a/swipl/src/blob.rs
+++ b/swipl/src/blob.rs
@@ -346,7 +346,7 @@ pub unsafe fn unify_with_arc<T>(
         blob_definition as *const fli::PL_blob_t as *mut fli::PL_blob_t,
     );
 
-    result != 0
+    (result as i32) != 0
 }
 
 /// Unify the term with the given Cloneable, using the given blob
@@ -372,7 +372,7 @@ pub unsafe fn unify_with_cloneable<T: Clone + Sized + Unpin>(
         blob_definition as *const fli::PL_blob_t as *mut fli::PL_blob_t,
     );
 
-    if result != 0 {
+    if (result as i32) != 0 {
         std::mem::forget(cloned);
         true
     } else {
@@ -395,7 +395,7 @@ pub unsafe fn get_arc_from_term<T>(
     term.assert_term_handling_possible();
 
     let mut blob_type = std::ptr::null_mut();
-    if fli::PL_is_blob(term.term_ptr(), &mut blob_type) == 0
+    if (fli::PL_is_blob(term.term_ptr(), &mut blob_type) as i32) == 0
         || blob_definition as *const fli::PL_blob_t != blob_type
     {
         return None;
@@ -409,7 +409,7 @@ pub unsafe fn get_arc_from_term<T>(
         std::ptr::null_mut(),
     );
 
-    if result == 0 {
+    if (result as i32) == 0 {
         None
     } else {
         Arc::increment_strong_count(data);
@@ -433,7 +433,7 @@ pub unsafe fn get_cloned_from_term<T: Clone + Sized + Unpin>(
     term.assert_term_handling_possible();
 
     let mut blob_type = std::ptr::null_mut();
-    if fli::PL_is_blob(term.term_ptr(), &mut blob_type) == 0
+    if (fli::PL_is_blob(term.term_ptr(), &mut blob_type) as i32) == 0
         || blob_definition as *const fli::PL_blob_t != blob_type
     {
         return None;
@@ -447,7 +447,7 @@ pub unsafe fn get_cloned_from_term<T: Clone + Sized + Unpin>(
         std::ptr::null_mut(),
     );
 
-    if result == 0 {
+    if (result as i32) == 0 {
         None
     } else {
         let cloned = (*data).clone();

--- a/swipl/src/callable.rs
+++ b/swipl/src/callable.rs
@@ -67,7 +67,7 @@ impl<const N: usize> Callable<N> for LazyCallablePredicate<N> {
     }
 }
 
-impl<'a, const N: usize> Callable<N> for &'a LazyCallablePredicate<N> {
+impl<const N: usize> Callable<N> for &LazyCallablePredicate<N> {
     type ContextType = OpenQuery;
 
     fn open<'b, C: ContextType>(

--- a/swipl/src/context.rs
+++ b/swipl/src/context.rs
@@ -200,7 +200,7 @@ impl<'a, T: ContextType> Context<'a, T> {
     }
 
     /// Return the engine pointer as a `TermOrigin`, which is used in the construction of a `Term` in unsafe code.
-    pub(crate) fn as_term_origin(&self) -> TermOrigin {
+    pub(crate) fn as_term_origin(&self) -> TermOrigin<'_> {
         unsafe { TermOrigin::new(self.engine_ptr()) }
     }
 
@@ -211,7 +211,7 @@ impl<'a, T: ContextType> Context<'a, T> {
     /// given term_t is indeed from this context. The caller will have
     /// to ensure that the term lives at least as long as this
     /// context.
-    pub unsafe fn wrap_term_ref(&self, term: term_t) -> Term {
+    pub unsafe fn wrap_term_ref(&self, term: term_t) -> Term<'_> {
         self.assert_activated();
         Term::new(term, self.as_term_origin())
     }
@@ -370,7 +370,7 @@ pub unsafe trait ContextType {}
 /// # use swipl::prelude::*;
 /// let engine = Engine::new();
 /// let activation = engine.activate();
-
+///
 /// let context: Context<ActivatedEngine> = activation.into();
 /// // Note: Context<_> would also work as a type annotation
 /// ```
@@ -605,7 +605,7 @@ impl<'a, C: FrameableContextType> Context<'a, C> {
     /// will become inactive, until the new context is dropped. This
     /// may happen implicitely, when it goes out of scope, or
     /// explicitely, by calling `close()` or `discard()` on it.
-    pub fn open_frame(&self) -> Context<Frame> {
+    pub fn open_frame(&self) -> Context<'_, Frame> {
         self.assert_activated();
         let fid = unsafe { PL_open_foreign_frame() };
 
@@ -640,7 +640,7 @@ impl<'a, T: QueryableContextType> Context<'a, T> {
     ///
     /// The term ref takes on the lifetime of the Context reference,
     /// ensuring that it cannot outlive the context that created it.
-    pub fn new_term_ref(&self) -> Term {
+    pub fn new_term_ref(&self) -> Term<'_> {
         self.assert_activated();
         unsafe {
             let term = PL_new_term_ref();
@@ -653,7 +653,7 @@ impl<'a, T: QueryableContextType> Context<'a, T> {
     /// The term refs all take on the lifetime of the Context
     /// reference, ensuring that it cannot outlive the context that
     /// created it.
-    pub fn new_term_refs<const N: usize>(&self) -> [Term; N] {
+    pub fn new_term_refs<const N: usize>(&self) -> [Term<'_>; N] {
         // TODO: this should be a compile time thing ideally
         // TODO: swipl 9.1.19 changed the paramater type to usize
         // if N > i32::MAX as usize {
@@ -687,7 +687,7 @@ impl<'a, T: QueryableContextType> Context<'a, T> {
     /// The term refs all take on the lifetime of the Context
     /// reference, ensuring that it cannot outlive the context that
     /// created it.
-    pub fn new_term_refs_vec(&self, count: usize) -> Vec<Term> {
+    pub fn new_term_refs_vec(&self, count: usize) -> Vec<Term<'_>> {
         #[allow(clippy::useless_conversion)]
         let mut term_ptr = unsafe { PL_new_term_refs(count.try_into().unwrap()) };
         let mut result = Vec::with_capacity(count);
@@ -723,7 +723,7 @@ impl<'a, T: QueryableContextType> Context<'a, T> {
         &self,
         callable: C,
         args: [&Term; N],
-    ) -> Context<C::ContextType> {
+    ) -> Context<'_, C::ContextType> {
         callable.open(self, None, args)
     }
 
@@ -762,7 +762,7 @@ impl<'a, T: QueryableContextType> Context<'a, T> {
         callable: C,
         module: Option<Module>,
         args: [&Term; N],
-    ) -> Context<C::ContextType> {
+    ) -> Context<'_, C::ContextType> {
         callable.open(self, module, args)
     }
 
@@ -772,7 +772,7 @@ impl<'a, T: QueryableContextType> Context<'a, T> {
     /// heavy lifting.
     ///
     /// Consider using the `term!` macro instead.
-    pub fn term_from_string(&self, s: &str) -> PrologResult<Term> {
+    pub fn term_from_string(&self, s: &str) -> PrologResult<Term<'_>> {
         let term = self.new_term_ref();
         let frame = self.open_frame();
 
@@ -892,7 +892,7 @@ impl<'a, T: QueryableContextType> Context<'a, T> {
     /// is known at compile time. If the actual list is larger than
     /// this, only the first N elements are used. If the list is
     /// smaller, the remaining terms in the array remain variables.
-    pub fn term_list_array<const N: usize>(&self, list: &Term) -> [Term; N] {
+    pub fn term_list_array<const N: usize>(&self, list: &Term) -> [Term<'_>; N] {
         self.assert_activated();
         // allocate these terms inside the scope of this context
         let terms = self.new_term_refs();
@@ -924,7 +924,7 @@ impl<'a, T: QueryableContextType> Context<'a, T> {
     /// to iterate over the elements, or don't care about garbage
     /// terms being created, consider using
     /// [term_list_iter](Context::term_list_iter).
-    pub fn term_list_vec(&self, list: &Term) -> Vec<Term> {
+    pub fn term_list_vec(&self, list: &Term) -> Vec<Term<'_>> {
         self.assert_activated();
         let frame = self.open_frame();
         let count = frame.term_list_iter(list).count();
@@ -951,7 +951,7 @@ impl<'a, T: QueryableContextType> Context<'a, T> {
     /// arity N. If this is true, N terms will be allocated in this
     /// context, unified with the argument terms of the compound, and
     /// returned as an array. If not, this method will fail.
-    pub fn compound_terms<const N: usize>(&self, compound: &Term) -> PrologResult<[Term; N]> {
+    pub fn compound_terms<const N: usize>(&self, compound: &Term) -> PrologResult<[Term<'_>; N]> {
         self.assert_activated();
         if N > (i32::MAX - 1) as usize {
             panic!("requested compound term array too large: {}", N);
@@ -985,7 +985,7 @@ impl<'a, T: QueryableContextType> Context<'a, T> {
     /// any arity. If this is true, arity terms will be allocated in
     /// this context, unified with the argument terms of the compound,
     /// and returned as a Vec. If not, this method will fail.
-    pub fn compound_terms_vec(&self, compound: &Term) -> PrologResult<Vec<Term>> {
+    pub fn compound_terms_vec(&self, compound: &Term) -> PrologResult<Vec<Term<'_>>> {
         self.assert_activated();
 
         let mut size = 0;
@@ -1018,7 +1018,7 @@ impl<'a, T: QueryableContextType> Context<'a, T> {
         &self,
         compound: &Term,
         count: usize,
-    ) -> PrologResult<Vec<Term>> {
+    ) -> PrologResult<Vec<Term<'_>>> {
         self.assert_activated();
 
         let mut size = 0;
@@ -1098,7 +1098,7 @@ impl<'a, T: QueryableContextType> Context<'a, T> {
         }
     }
 
-    pub fn into_generic(&self) -> GenericQueryableContext {
+    pub fn into_generic(&self) -> GenericQueryableContext<'_> {
         self.assert_activated();
         self.activated.set(false);
         unsafe { Context::new_activated(self, GenericQueryableContextType, self.engine) }

--- a/swipl/src/context.rs
+++ b/swipl/src/context.rs
@@ -76,7 +76,7 @@ pub(crate) unsafe fn with_cleared_exception<R>(f: impl FnOnce() -> R) -> R {
     let error_term_ref = pl_default_exception();
     if error_term_ref != 0 {
         let backup_term_ref = PL_new_term_ref();
-        assert!(PL_unify(backup_term_ref, error_term_ref) != 0);
+        assert!((PL_unify(backup_term_ref, error_term_ref) as i32) != 0);
         PL_clear_exception();
         let result = f();
         PL_raise_exception(backup_term_ref);
@@ -117,7 +117,7 @@ impl<'a> ExceptionTerm<'a> {
     ) -> R {
         ctx.assert_activated();
         let backup_term_ref = PL_new_term_ref();
-        assert!(PL_unify(backup_term_ref, self.0.term_ptr()) != 0);
+        assert!((PL_unify(backup_term_ref, self.0.term_ptr()) as i32) != 0);
         let backup_term = Term::new(backup_term_ref, ctx.as_term_origin());
         PL_clear_exception();
 
@@ -958,7 +958,9 @@ impl<'a, T: QueryableContextType> Context<'a, T> {
 
         let mut size = 0;
         if unsafe {
-            PL_get_compound_name_arity(compound.term_ptr(), std::ptr::null_mut(), &mut size) != 1
+            (PL_get_compound_name_arity(compound.term_ptr(), std::ptr::null_mut(), &mut size)
+                as i32)
+                != 1
         } {
             return Err(PrologError::Failure);
         }
@@ -969,7 +971,9 @@ impl<'a, T: QueryableContextType> Context<'a, T> {
         let terms: [Term; N] = self.new_term_refs();
         for (i, term) in terms.iter().enumerate() {
             unsafe {
-                assert!(PL_get_arg((i + 1) as i32, compound.term_ptr(), term.term_ptr()) == 1);
+                assert!(
+                    (PL_get_arg((i + 1) as i32, compound.term_ptr(), term.term_ptr()) as i32) == 1
+                );
             }
         }
 
@@ -987,7 +991,9 @@ impl<'a, T: QueryableContextType> Context<'a, T> {
 
         let mut size = 0;
         if unsafe {
-            PL_get_compound_name_arity(compound.term_ptr(), std::ptr::null_mut(), &mut size) != 1
+            (PL_get_compound_name_arity(compound.term_ptr(), std::ptr::null_mut(), &mut size)
+                as i32)
+                != 1
         } {
             return Err(PrologError::Failure);
         }
@@ -995,7 +1001,9 @@ impl<'a, T: QueryableContextType> Context<'a, T> {
         let terms = self.new_term_refs_vec(size as usize);
         for (i, term) in terms.iter().enumerate() {
             unsafe {
-                assert!(PL_get_arg((i + 1) as i32, compound.term_ptr(), term.term_ptr()) == 1);
+                assert!(
+                    (PL_get_arg((i + 1) as i32, compound.term_ptr(), term.term_ptr()) as i32) == 1
+                );
             }
         }
 
@@ -1018,7 +1026,9 @@ impl<'a, T: QueryableContextType> Context<'a, T> {
 
         let mut size = 0;
         if unsafe {
-            PL_get_compound_name_arity(compound.term_ptr(), std::ptr::null_mut(), &mut size) != 1
+            (PL_get_compound_name_arity(compound.term_ptr(), std::ptr::null_mut(), &mut size)
+                as i32)
+                != 1
         } {
             return Err(PrologError::Failure);
         }
@@ -1029,7 +1039,9 @@ impl<'a, T: QueryableContextType> Context<'a, T> {
         let terms = self.new_term_refs_vec(count);
         for (i, term) in terms.iter().enumerate() {
             unsafe {
-                assert!(PL_get_arg((i + 1) as i32, compound.term_ptr(), term.term_ptr()) == 1);
+                assert!(
+                    (PL_get_arg((i + 1) as i32, compound.term_ptr(), term.term_ptr()) as i32) == 1
+                );
             }
         }
 
@@ -1076,7 +1088,7 @@ impl<'a, T: QueryableContextType> Context<'a, T> {
         term: &Term,
     ) -> Result<(Term<'b>, Term<'b>), PrologError> {
         let [head, tail] = self.new_term_refs();
-        match unsafe { PL_unify_list(term.term_ptr(), head.term_ptr(), tail.term_ptr()) } {
+        match (unsafe { PL_unify_list(term.term_ptr(), head.term_ptr(), tail.term_ptr()) } as i32) {
             0 => {
                 unsafe {
                     head.reset();
@@ -1112,8 +1124,9 @@ impl<'a, 'b, CT: QueryableContextType> Iterator for TermListIterator<'a, 'b, CT>
     fn next(&mut self) -> Option<Term<'a>> {
         let head = self.context.new_term_ref();
         let tail = self.context.new_term_ref();
-        let success =
-            unsafe { PL_get_list(self.cur.term_ptr(), head.term_ptr(), tail.term_ptr()) != 0 };
+        let success = (unsafe { PL_get_list(self.cur.term_ptr(), head.term_ptr(), tail.term_ptr()) }
+            as i32)
+            != 0;
 
         if success {
             self.cur = tail;

--- a/swipl/src/dict.rs
+++ b/swipl/src/dict.rs
@@ -87,7 +87,7 @@ pub trait IntoKey {
     fn atom_ptr(self) -> (fli::atom_t, Option<Atom>);
 }
 
-impl<'a, A: AsAtom + ?Sized> IntoKey for &'a A {
+impl<A: AsAtom + ?Sized> IntoKey for &A {
     fn atom_ptr(self) -> (fli::atom_t, Option<Atom>) {
         self.as_atom_ptr()
     }
@@ -126,7 +126,6 @@ impl IntoKey for u64 {
 ///     bar: "hello"
 /// }
 /// ```
-
 pub struct DictBuilder<'a> {
     tag: DictTag<'a>,
     entries: HashMap<Key, Option<Box<dyn TermPutable + 'a>>>,

--- a/swipl/src/dict.rs
+++ b/swipl/src/dict.rs
@@ -33,11 +33,17 @@ impl<A: IntoAtom> From<A> for Key {
     }
 }
 
+const SMALL_INT_MAX: u64 = (1 << 56) - 1;
+
 fn int_to_atom_t(val: u64) -> fli::atom_t {
     // SWI-Prolog represents integer dict keys as a special kind of atom_t.
     // Use the runtime helper rather than relying on internal tagging details.
-    if val > i64::MAX as u64 {
-        panic!("val {} is too large to be converted to a dict key", val);
+    // Note: _PL_cons_small_int silently returns 0 for values >= 2^56.
+    if val > SMALL_INT_MAX {
+        panic!(
+            "val {} exceeds the 56-bit limit for integer dict keys (max: {}, i.e. 2^56 - 1)",
+            val, SMALL_INT_MAX
+        );
     }
 
     unsafe { fli::_PL_cons_small_int(val as i64) }
@@ -592,6 +598,77 @@ mod tests {
             .unwrap();
         let string = string_term.get::<String>().unwrap();
         assert_eq!("foo{11:bar,42:foo}", string);
+    }
+
+    #[test]
+    fn small_int_tagging_roundtrip() {
+        // Verify that _PL_cons_small_int produces values that atom_t_to_small_int can detect.
+        // This test validates the asymmetric encode/decode assumption.
+        let _engine = Engine::new();
+
+        let test_values: &[u64] = &[
+            0,
+            1,
+            42,
+            255,
+            256,
+            65535,
+            1 << 20,
+            1 << 30,
+        ];
+
+        for &val in test_values {
+            let encoded = int_to_atom_t(val);
+            let decoded = atom_t_to_small_int(encoded);
+
+            assert!(
+                decoded.is_some(),
+                "atom_t_to_small_int failed to detect integer key for value {}. \
+                 Encoded atom_t: {:#x}, low 7 bits: {:#x} (expected 0x3)",
+                val,
+                encoded as u64,
+                (encoded as u64) & 0x7f
+            );
+
+            assert_eq!(
+                decoded.unwrap(),
+                val,
+                "Round-trip failed for value {}: encoded {:#x}, decoded {:?}",
+                val,
+                encoded as u64,
+                decoded
+            );
+        }
+    }
+
+    #[test]
+    fn small_int_find_limit() {
+        // Find the actual limit of _PL_cons_small_int in this SWI-Prolog version.
+        let _engine = Engine::new();
+
+        let mut last_working_bits = 0;
+        for bits in 1..=63 {
+            let val = (1_u64 << bits) - 1;
+            let encoded = unsafe { fli::_PL_cons_small_int(val as i64) };
+
+            if encoded == 0 || atom_t_to_small_int(encoded) != Some(val) {
+                eprintln!(
+                    "Small int limit found: {} bits work, {} bits fail. Max value: {}",
+                    last_working_bits,
+                    bits,
+                    (1_u64 << last_working_bits) - 1
+                );
+                break;
+            }
+            last_working_bits = bits;
+        }
+
+        // The limit should be documented - assert a reasonable minimum
+        assert!(
+            last_working_bits >= 30,
+            "Small int limit unexpectedly low: only {} bits",
+            last_working_bits
+        );
     }
 
     #[test]

--- a/swipl/src/engine.rs
+++ b/swipl/src/engine.rs
@@ -125,7 +125,7 @@ impl Engine {
         is_engine_active(self.engine_ptr)
     }
 
-    pub(crate) unsafe fn set_activated(&self) -> EngineActivation {
+    pub(crate) unsafe fn set_activated(&self) -> EngineActivation<'_> {
         if self
             .active
             .compare_exchange(
@@ -150,7 +150,7 @@ impl Engine {
     /// This will panic if an engine is already active on this
     /// thread. Otherwise, it'll return an `EngineActivation` whose
     /// lifetime is bound to this engine.
-    pub fn activate(&self) -> EngineActivation {
+    pub fn activate(&self) -> EngineActivation<'_> {
         if Self::some_engine_active() {
             panic!("tried to activate engine on a thread that already has an active engine");
         }

--- a/swipl/src/functor.rs
+++ b/swipl/src/functor.rs
@@ -10,6 +10,7 @@ use super::atom::*;
 use super::consts::*;
 use super::engine::*;
 use super::fli::*;
+use super::fli::FliSuccess;
 use super::term::*;
 
 use std::convert::TryInto;
@@ -105,7 +106,7 @@ unifiable! {
     (self: Functor, term) => {
         let result = unsafe {PL_unify_compound(term.term_ptr(), self.functor)};
 
-        (result as i32) != 0
+        result.is_success()
     }
 }
 
@@ -114,7 +115,7 @@ term_getable! {
         let mut functor = 0;
         let result = unsafe { PL_get_functor(term.term_ptr(), &mut functor) };
 
-        if (result as i32) == 0 {
+        if !result.is_success() {
             None
         }
         else {

--- a/swipl/src/functor.rs
+++ b/swipl/src/functor.rs
@@ -105,7 +105,7 @@ unifiable! {
     (self: Functor, term) => {
         let result = unsafe {PL_unify_compound(term.term_ptr(), self.functor)};
 
-        result != 0
+        (result as i32) != 0
     }
 }
 
@@ -114,7 +114,7 @@ term_getable! {
         let mut functor = 0;
         let result = unsafe { PL_get_functor(term.term_ptr(), &mut functor) };
 
-        if result == 0 {
+        if (result as i32) == 0 {
             None
         }
         else {

--- a/swipl/src/init.rs
+++ b/swipl/src/init.rs
@@ -204,7 +204,7 @@ pub unsafe fn register_foreign_in_module(
         .map(|m| m.as_ptr())
         .unwrap_or(std::ptr::null_mut());
 
-    (PL_register_foreign_in_module(
+    PL_register_foreign_in_module(
         c_module_ptr,
         c_name.as_ptr(),
         arity as c_int,

--- a/swipl/src/init.rs
+++ b/swipl/src/init.rs
@@ -9,8 +9,8 @@
 //! predicate registration are defined here.
 
 use crate::engine::*;
-use crate::fli::*;
 use crate::fli::FliSuccess;
+use crate::fli::*;
 
 use lazy_static::*;
 use std::convert::TryInto;
@@ -118,7 +118,11 @@ fn initialize_internal(
     unsafe { PL_initialise(2, args.as_mut_ptr()) };
     *initialized = Some(unsafe { Engine::from_current() });
 
-    Some(unsafe { std::mem::transmute((*initialized).as_ref().unwrap().set_activated()) })
+    Some(unsafe {
+        std::mem::transmute::<EngineActivation<'_>, EngineActivation<'static>>(
+            (*initialized).as_ref().unwrap().set_activated(),
+        )
+    })
 }
 
 /// Initialize SWI-Prolog and immediately deactivate the main thread engine.
@@ -150,7 +154,11 @@ pub fn reactivate_swipl() -> EngineActivation<'static> {
     let initialized = INITIALIZATION_STATE.read().unwrap();
 
     if let Some(engine) = initialized.as_ref() {
-        unsafe { std::mem::transmute(engine.activate()) }
+        unsafe {
+            std::mem::transmute::<EngineActivation<'_>, EngineActivation<'static>>(
+                engine.activate(),
+            )
+        }
     } else {
         panic!("swipl-rs cannot reactiate the main engine because SWI-Prolog was not initialized, or initialized externally.");
     }
@@ -198,7 +206,9 @@ pub unsafe fn register_foreign_in_module(
     //
     // SWI-Prolog 10 defines pl_function_t as void*; older versions used a function pointer type.
     // We keep a single call site by transmuting into the bindgen-generated type.
-    let converted_function_ptr: pl_function_t = std::mem::transmute(function_ptr);
+    #[allow(clippy::transmutes_expressible_as_ptr_casts)]
+    let converted_function_ptr: pl_function_t =
+        std::mem::transmute::<_, pl_function_t>(function_ptr);
     let c_module_ptr = c_module
         .as_ref()
         .map(|m| m.as_ptr())
@@ -211,5 +221,6 @@ pub unsafe fn register_foreign_in_module(
         converted_function_ptr,
         flags.try_into().unwrap(),
         c_meta.map(|m| m.as_ptr()).unwrap_or_else(std::ptr::null),
-    ).is_success()
+    )
+    .is_success()
 }

--- a/swipl/src/init.rs
+++ b/swipl/src/init.rs
@@ -10,6 +10,7 @@
 
 use crate::engine::*;
 use crate::fli::*;
+use crate::fli::FliSuccess;
 
 use lazy_static::*;
 use std::convert::TryInto;
@@ -30,7 +31,7 @@ pub fn activate_main() -> EngineActivation<'static> {
 
 /// Check if SWI-Prolog has been initialized.
 pub fn is_swipl_initialized() -> bool {
-    (unsafe { PL_is_initialised(std::ptr::null_mut(), std::ptr::null_mut()) } as i32) != 0
+    unsafe { PL_is_initialised(std::ptr::null_mut(), std::ptr::null_mut()) }.is_success()
 }
 
 /// Panic if SWI-Prolog has not been initialized.
@@ -96,7 +97,7 @@ pub fn initialize_swipl_with_state(state: &'static [u8]) -> Option<EngineActivat
     // https://www.swi-prolog.org/pldoc/doc_for?object=c(%27PL_set_resource_db_mem%27)
     let result = unsafe { PL_set_resource_db_mem(state.as_ptr(), state.len()) };
 
-    if (result as i32) == 0 {
+    if !result.is_success() {
         return None;
     }
 
@@ -210,6 +211,5 @@ pub unsafe fn register_foreign_in_module(
         converted_function_ptr,
         flags.try_into().unwrap(),
         c_meta.map(|m| m.as_ptr()).unwrap_or_else(std::ptr::null),
-    ) as i32)
-        != 0
+    ).is_success()
 }

--- a/swipl/src/record.rs
+++ b/swipl/src/record.rs
@@ -6,6 +6,7 @@
 //! automatically on drop of a wrapper object.
 
 use super::fli;
+use super::fli::FliSuccess;
 use super::result::*;
 use super::term::*;
 use crate::{term_getable, term_putable, unifiable};
@@ -33,7 +34,7 @@ impl Record {
     /// Copy the recorded term into the given term reference.
     pub fn recorded(&self, term: &Term) -> PrologResult<()> {
         term.assert_term_handling_possible();
-        unsafe { into_prolog_result((fli::PL_recorded(self.record, term.term_ptr()) as i32) != 0) }
+        unsafe { into_prolog_result(fli::PL_recorded(self.record, term.term_ptr()).is_success()) }
     }
 }
 
@@ -77,7 +78,7 @@ unifiable! {
             let result = fli::PL_unify(term.term_ptr(), extra_term);
             fli::PL_reset_term_refs(extra_term);
 
-            (result as i32) != 0
+            result.is_success()
         }
     }
 }

--- a/swipl/src/record.rs
+++ b/swipl/src/record.rs
@@ -33,7 +33,7 @@ impl Record {
     /// Copy the recorded term into the given term reference.
     pub fn recorded(&self, term: &Term) -> PrologResult<()> {
         term.assert_term_handling_possible();
-        unsafe { into_prolog_result(fli::PL_recorded(self.record, term.term_ptr()) != 0) }
+        unsafe { into_prolog_result((fli::PL_recorded(self.record, term.term_ptr()) as i32) != 0) }
     }
 }
 
@@ -77,7 +77,7 @@ unifiable! {
             let result = fli::PL_unify(term.term_ptr(), extra_term);
             fli::PL_reset_term_refs(extra_term);
 
-            result != 0
+            (result as i32) != 0
         }
     }
 }

--- a/swipl/src/stream.rs
+++ b/swipl/src/stream.rs
@@ -160,7 +160,7 @@ impl<'a> Write for WritablePrologStream<'a> {
 
         match (result, error) {
             (0, 0) => Ok(()),
-            _ => Err(io::Error::new(io::ErrorKind::Other, "prolog flush failed")),
+            _ => Err(io::Error::other("prolog flush failed")),
         }
     }
 }
@@ -180,7 +180,7 @@ impl Write for PrologStream {
         }
         match (result, error) {
             (0, 0) => Ok(()),
-            _ => Err(io::Error::new(io::ErrorKind::Other, "prolog flush failed")),
+            _ => Err(io::Error::other("prolog flush failed")),
         }
     }
 }

--- a/swipl/src/stream.rs
+++ b/swipl/src/stream.rs
@@ -11,6 +11,7 @@ use num_enum::FromPrimitive;
 use crate::engine::*;
 use crate::term::*;
 use crate::{fli, term_getable};
+use crate::fli::FliSuccess;
 
 /// A stream from prolog, used in blob writers.
 pub struct PrologStream {
@@ -72,15 +73,7 @@ term_getable! {
     // origin.
     (WritablePrologStream<'a>, term) => {
         let mut stream: *mut fli::IOSTREAM = std::ptr::null_mut();
-        if (unsafe {
-            fli::PL_get_stream(
-                term.term_ptr(),
-                &mut stream,
-                fli::SH_OUTPUT | fli::SH_UNLOCKED | fli::SH_NOPAIR,
-            )
-        } as i32)
-            != 0
-        {
+        if unsafe { fli::PL_get_stream(term.term_ptr(), &mut stream, fli::SH_OUTPUT|fli::SH_UNLOCKED|fli::SH_NOPAIR) }.is_success() {
             Some(unsafe {WritablePrologStream::new(stream) })
         }
         else {
@@ -281,15 +274,7 @@ term_getable! {
     // origin.
     (ReadablePrologStream<'a>, term) => {
         let mut stream: *mut fli::IOSTREAM = std::ptr::null_mut();
-        if (unsafe {
-            fli::PL_get_stream(
-                term.term_ptr(),
-                &mut stream,
-                fli::SH_INPUT | fli::SH_UNLOCKED | fli::SH_NOPAIR,
-            )
-        } as i32)
-            != 0
-        {
+        if unsafe { fli::PL_get_stream(term.term_ptr(), &mut stream, fli::SH_INPUT|fli::SH_UNLOCKED|fli::SH_NOPAIR) }.is_success() {
             Some(unsafe {ReadablePrologStream::new(stream) })
         }
         else {

--- a/swipl/src/stream.rs
+++ b/swipl/src/stream.rs
@@ -72,7 +72,15 @@ term_getable! {
     // origin.
     (WritablePrologStream<'a>, term) => {
         let mut stream: *mut fli::IOSTREAM = std::ptr::null_mut();
-        if unsafe { fli::PL_get_stream(term.term_ptr(), &mut stream, fli::SH_OUTPUT|fli::SH_UNLOCKED|fli::SH_NOPAIR) } != 0 {
+        if (unsafe {
+            fli::PL_get_stream(
+                term.term_ptr(),
+                &mut stream,
+                fli::SH_OUTPUT | fli::SH_UNLOCKED | fli::SH_NOPAIR,
+            )
+        } as i32)
+            != 0
+        {
             Some(unsafe {WritablePrologStream::new(stream) })
         }
         else {
@@ -273,7 +281,15 @@ term_getable! {
     // origin.
     (ReadablePrologStream<'a>, term) => {
         let mut stream: *mut fli::IOSTREAM = std::ptr::null_mut();
-        if unsafe { fli::PL_get_stream(term.term_ptr(), &mut stream, fli::SH_INPUT|fli::SH_UNLOCKED|fli::SH_NOPAIR) } != 0 {
+        if (unsafe {
+            fli::PL_get_stream(
+                term.term_ptr(),
+                &mut stream,
+                fli::SH_INPUT | fli::SH_UNLOCKED | fli::SH_NOPAIR,
+            )
+        } as i32)
+            != 0
+        {
             Some(unsafe {ReadablePrologStream::new(stream) })
         }
         else {

--- a/swipl/src/term/mod.rs
+++ b/swipl/src/term/mod.rs
@@ -993,11 +993,7 @@ unifiable! {
 
 term_getable! {
     (String, "string", term) => {
-        match term.get_str(|s|s.map(|s|s.to_owned())) {
-            Ok(r) => r,
-            // ignore error - it'll be picked up by the wrapper
-            Err(_) => None
-        }
+        term.get_str(|s|s.map(|s|s.to_owned())).unwrap_or_default()
     }
 }
 

--- a/swipl/src/term/mod.rs
+++ b/swipl/src/term/mod.rs
@@ -33,6 +33,7 @@ use super::atom::*;
 use super::context::*;
 use super::engine::*;
 use super::fli::*;
+use super::fli::FliSuccess;
 use super::record::*;
 use super::result::*;
 use std::cmp::{Ordering, PartialOrd};
@@ -120,25 +121,25 @@ impl<'a> Term<'a> {
     /// Returns true if this term reference holds a variable.
     pub fn is_var(&self) -> bool {
         self.assert_term_handling_possible();
-        (unsafe { PL_is_variable(self.term) } as i32) != 0
+        unsafe { PL_is_variable(self.term) }.is_success()
     }
 
     /// Returns true if this term reference holds an atom.
     pub fn is_atom(&self) -> bool {
         self.assert_term_handling_possible();
-        (unsafe { PL_is_atom(self.term) } as i32) != 0
+        unsafe { PL_is_atom(self.term) }.is_success()
     }
 
     /// Returns true if this term reference holds a string.
     pub fn is_string(&self) -> bool {
         self.assert_term_handling_possible();
-        (unsafe { PL_is_string(self.term) } as i32) != 0
+        unsafe { PL_is_string(self.term) }.is_success()
     }
 
     /// Returns true if this term reference holds an integer.
     pub fn is_integer(&self) -> bool {
         self.assert_term_handling_possible();
-        (unsafe { PL_is_integer(self.term) } as i32) != 0
+        unsafe { PL_is_integer(self.term) }.is_success()
     }
 
     /// Reset terms created after this term, including this term itself.
@@ -210,7 +211,7 @@ impl<'a> Term<'a> {
 
         let arg = unsafe { Term::new(arg_ref, self.origin.clone()) };
         let mut result2 = Err(PrologError::Failure);
-        if (result as i32) != 0 {
+        if result.is_success() {
             result2 = arg.unify(unifiable);
         }
 
@@ -321,7 +322,7 @@ impl<'a> Term<'a> {
 
         let arg = unsafe { Term::new(arg_ref, self.origin.clone()) };
         let mut result2 = Err(PrologError::Failure);
-        if (result as i32) != 0 {
+        if result.is_success() {
             result2 = arg.get();
         }
 
@@ -356,7 +357,7 @@ impl<'a> Term<'a> {
         }
 
         let arg = unsafe { Term::new(arg_ref, self.origin.clone()) };
-        let result2 = if (result as i32) != 0 {
+        let result2 = if result.is_success() {
             arg.get_ex()
         } else {
             let context = unsafe { unmanaged_engine_context() };
@@ -393,7 +394,7 @@ impl<'a> Term<'a> {
             return Err(PrologError::Exception);
         }
 
-        let arg = if (result as i32) == 0 {
+        let arg = if !result.is_success() {
             None
         } else {
             let swipl_string_ref = unsafe { std::slice::from_raw_parts(ptr as *const u8, len) };
@@ -442,7 +443,7 @@ impl<'a> Term<'a> {
             return Err(PrologError::Exception);
         }
 
-        let arg = if (result as i32) == 0 {
+        let arg = if !result.is_success() {
             None
         } else {
             let swipl_string_ref = unsafe { std::slice::from_raw_parts(ptr as *const u8, len) };
@@ -779,7 +780,7 @@ unifiable! {
         let result = unsafe { PL_unify(self.term, term.term) };
 
         // TODO we should actually properly test for an exception here.
-        (result as i32) != 0
+        result.is_success()
     }
 }
 
@@ -801,7 +802,7 @@ unifiable! {
         };
         let result = unsafe { PL_unify_bool(term.term, num) };
 
-        (result as i32) != 0
+        result.is_success()
     }
 }
 
@@ -809,7 +810,7 @@ term_getable! {
     (bool, term) => {
         let mut out = 0;
         let result = unsafe { PL_get_bool(term.term, &mut out) };
-        if (result as i32) == 0 {
+        if !result.is_success() {
             None
         }
         else {
@@ -857,7 +858,7 @@ unifiable! {
                 false
             }
             else {
-                (result as i32) != 0
+                result.is_success()
             }
         })}
     }
@@ -865,7 +866,7 @@ unifiable! {
 
 term_getable! {
     (u64, "integer", term) => {
-        if (unsafe { PL_is_integer(term.term) } as i32) == 0 {
+        if !unsafe { PL_is_integer(term.term) }.is_success() {
             return None;
         }
 
@@ -892,7 +893,7 @@ term_getable! {
                 error_term.reset();
                 None
             }
-            else if (result as i32) == 0 {
+            else if !result.is_success() {
                 None
             }
             else {
@@ -912,7 +913,7 @@ unifiable! {
     (self:i64, term) => {
         let result = unsafe { PL_unify_int64(term.term, *self) };
 
-        (result as i32) != 0
+        result.is_success()
     }
 }
 
@@ -920,7 +921,7 @@ term_getable! {
     (i64, "integer", term) => {
         let mut out = 0;
         let result = unsafe { PL_get_int64(term.term, &mut out) };
-        if (result as i32) == 0 {
+        if !result.is_success() {
             None
         }
         else {
@@ -939,7 +940,7 @@ unifiable! {
     (self:f64, term) => {
         let result = unsafe { PL_unify_float(term.term, *self) };
 
-        (result as i32) != 0
+        result.is_success()
     }
 }
 
@@ -947,7 +948,7 @@ term_getable! {
     (f64, "float", term) => {
         let mut out = 0.0;
         let result = unsafe { PL_get_float(term.term, &mut out) };
-        if (result as i32) == 0 {
+        if !result.is_success() {
             None
         }
         else {
@@ -972,7 +973,7 @@ unifiable! {
         )
         };
 
-        (result as i32) != 0
+        result.is_success()
     }
 }
 
@@ -986,7 +987,7 @@ unifiable! {
         )
         };
 
-        (result as i32) != 0
+        result.is_success()
     }
 }
 
@@ -1028,7 +1029,7 @@ unifiable! {
     (self: &[u8], term) => {
         let result = unsafe { PL_unify_string_nchars(term.term_ptr(), self.len(), self.as_ptr() as *const std::os::raw::c_char) };
 
-        (result as i32) != 0
+        result.is_success()
     }
 }
 
@@ -1037,7 +1038,7 @@ term_getable! {
         let mut string_ptr = std::ptr::null_mut();
         let mut len = 0;
         let result = unsafe { PL_get_string(term.term_ptr(), &mut string_ptr, &mut len) };
-        if (result as i32) == 0 {
+        if !result.is_success() {
             return None;
         }
 
@@ -1062,7 +1063,7 @@ unifiable! {
     (self:Nil, term) => {
         let result = unsafe { PL_unify_nil(term.term_ptr()) };
 
-        (result as i32) != 0
+        result.is_success()
     }
 }
 
@@ -1070,7 +1071,7 @@ term_getable! {
     (Nil, "list", term) => {
         let result = unsafe { PL_get_nil(term.term_ptr()) };
 
-        match (result as i32) != 0 {
+        match result.is_success() {
             true => Some(Nil),
             false => None
         }
@@ -1109,8 +1110,7 @@ where
             // if list unification fails, or head can not be unified with current term,
             // return false early.
             // note: || is short-circuiting OR
-            if (unsafe { PL_unify_list(list.term_ptr(), head.term_ptr(), tail.term_ptr()) } as i32)
-                == 0
+            if !unsafe { PL_unify_list(list.term_ptr(), head.term_ptr(), tail.term_ptr()) }.is_success()
                 || head.unify(t).is_err()
             {
                 return false;
@@ -1126,7 +1126,7 @@ where
             frame2.close();
         }
 
-        let success = (unsafe { PL_unify_nil(list.term_ptr()) } as i32) != 0;
+        let success = unsafe { PL_unify_nil(list.term_ptr()) }.is_success();
         frame.close();
 
         success
@@ -1148,16 +1148,14 @@ unsafe impl<T: TermGetable> TermGetable for Vec<T> {
         list.unify(term).unwrap();
         let mut success = true;
         loop {
-            if (unsafe { PL_get_nil(list.term_ptr()) } as i32) != 0 {
+            if unsafe { PL_get_nil(list.term_ptr()) }.is_success() {
                 break;
             }
 
             let frame2 = frame.open_frame();
             let head = frame2.new_term_ref();
             let tail = frame2.new_term_ref();
-            success = (unsafe { PL_get_list(list.term_ptr(), head.term_ptr(), tail.term_ptr()) }
-                as i32)
-                != 0;
+            success = unsafe { PL_get_list(list.term_ptr(), head.term_ptr(), tail.term_ptr()) }.is_success();
 
             if !success {
                 break;

--- a/swipl/src/term/mod.rs
+++ b/swipl/src/term/mod.rs
@@ -120,25 +120,25 @@ impl<'a> Term<'a> {
     /// Returns true if this term reference holds a variable.
     pub fn is_var(&self) -> bool {
         self.assert_term_handling_possible();
-        unsafe { PL_is_variable(self.term) != 0 }
+        (unsafe { PL_is_variable(self.term) } as i32) != 0
     }
 
     /// Returns true if this term reference holds an atom.
     pub fn is_atom(&self) -> bool {
         self.assert_term_handling_possible();
-        unsafe { PL_is_atom(self.term) != 0 }
+        (unsafe { PL_is_atom(self.term) } as i32) != 0
     }
 
     /// Returns true if this term reference holds a string.
     pub fn is_string(&self) -> bool {
         self.assert_term_handling_possible();
-        unsafe { PL_is_string(self.term) != 0 }
+        (unsafe { PL_is_string(self.term) } as i32) != 0
     }
 
     /// Returns true if this term reference holds an integer.
     pub fn is_integer(&self) -> bool {
         self.assert_term_handling_possible();
-        unsafe { PL_is_integer(self.term) != 0 }
+        (unsafe { PL_is_integer(self.term) } as i32) != 0
     }
 
     /// Reset terms created after this term, including this term itself.
@@ -210,7 +210,7 @@ impl<'a> Term<'a> {
 
         let arg = unsafe { Term::new(arg_ref, self.origin.clone()) };
         let mut result2 = Err(PrologError::Failure);
-        if result != 0 {
+        if (result as i32) != 0 {
             result2 = arg.unify(unifiable);
         }
 
@@ -321,7 +321,7 @@ impl<'a> Term<'a> {
 
         let arg = unsafe { Term::new(arg_ref, self.origin.clone()) };
         let mut result2 = Err(PrologError::Failure);
-        if result != 0 {
+        if (result as i32) != 0 {
             result2 = arg.get();
         }
 
@@ -356,7 +356,7 @@ impl<'a> Term<'a> {
         }
 
         let arg = unsafe { Term::new(arg_ref, self.origin.clone()) };
-        let result2 = if result != 0 {
+        let result2 = if (result as i32) != 0 {
             arg.get_ex()
         } else {
             let context = unsafe { unmanaged_engine_context() };
@@ -393,7 +393,7 @@ impl<'a> Term<'a> {
             return Err(PrologError::Exception);
         }
 
-        let arg = if result == 0 {
+        let arg = if (result as i32) == 0 {
             None
         } else {
             let swipl_string_ref = unsafe { std::slice::from_raw_parts(ptr as *const u8, len) };
@@ -442,7 +442,7 @@ impl<'a> Term<'a> {
             return Err(PrologError::Exception);
         }
 
-        let arg = if result == 0 {
+        let arg = if (result as i32) == 0 {
             None
         } else {
             let swipl_string_ref = unsafe { std::slice::from_raw_parts(ptr as *const u8, len) };
@@ -779,7 +779,7 @@ unifiable! {
         let result = unsafe { PL_unify(self.term, term.term) };
 
         // TODO we should actually properly test for an exception here.
-        result != 0
+        (result as i32) != 0
     }
 }
 
@@ -801,7 +801,7 @@ unifiable! {
         };
         let result = unsafe { PL_unify_bool(term.term, num) };
 
-        result != 0
+        (result as i32) != 0
     }
 }
 
@@ -809,7 +809,7 @@ term_getable! {
     (bool, term) => {
         let mut out = 0;
         let result = unsafe { PL_get_bool(term.term, &mut out) };
-        if result == 0 {
+        if (result as i32) == 0 {
             None
         }
         else {
@@ -857,7 +857,7 @@ unifiable! {
                 false
             }
             else {
-                result != 0
+                (result as i32) != 0
             }
         })}
     }
@@ -865,7 +865,7 @@ unifiable! {
 
 term_getable! {
     (u64, "integer", term) => {
-        if unsafe { PL_is_integer(term.term) == 0 } {
+        if (unsafe { PL_is_integer(term.term) } as i32) == 0 {
             return None;
         }
 
@@ -892,7 +892,7 @@ term_getable! {
                 error_term.reset();
                 None
             }
-            else if result == 0 {
+            else if (result as i32) == 0 {
                 None
             }
             else {
@@ -912,7 +912,7 @@ unifiable! {
     (self:i64, term) => {
         let result = unsafe { PL_unify_int64(term.term, *self) };
 
-        result != 0
+        (result as i32) != 0
     }
 }
 
@@ -920,7 +920,7 @@ term_getable! {
     (i64, "integer", term) => {
         let mut out = 0;
         let result = unsafe { PL_get_int64(term.term, &mut out) };
-        if result == 0 {
+        if (result as i32) == 0 {
             None
         }
         else {
@@ -939,7 +939,7 @@ unifiable! {
     (self:f64, term) => {
         let result = unsafe { PL_unify_float(term.term, *self) };
 
-        result != 0
+        (result as i32) != 0
     }
 }
 
@@ -947,7 +947,7 @@ term_getable! {
     (f64, "float", term) => {
         let mut out = 0.0;
         let result = unsafe { PL_get_float(term.term, &mut out) };
-        if result == 0 {
+        if (result as i32) == 0 {
             None
         }
         else {
@@ -972,7 +972,7 @@ unifiable! {
         )
         };
 
-        result != 0
+        (result as i32) != 0
     }
 }
 
@@ -986,7 +986,7 @@ unifiable! {
         )
         };
 
-        result != 0
+        (result as i32) != 0
     }
 }
 
@@ -1028,7 +1028,7 @@ unifiable! {
     (self: &[u8], term) => {
         let result = unsafe { PL_unify_string_nchars(term.term_ptr(), self.len(), self.as_ptr() as *const std::os::raw::c_char) };
 
-        result != 0
+        (result as i32) != 0
     }
 }
 
@@ -1037,7 +1037,7 @@ term_getable! {
         let mut string_ptr = std::ptr::null_mut();
         let mut len = 0;
         let result = unsafe { PL_get_string(term.term_ptr(), &mut string_ptr, &mut len) };
-        if result == 0 {
+        if (result as i32) == 0 {
             return None;
         }
 
@@ -1062,7 +1062,7 @@ unifiable! {
     (self:Nil, term) => {
         let result = unsafe { PL_unify_nil(term.term_ptr()) };
 
-        result != 0
+        (result as i32) != 0
     }
 }
 
@@ -1070,7 +1070,7 @@ term_getable! {
     (Nil, "list", term) => {
         let result = unsafe { PL_get_nil(term.term_ptr()) };
 
-        match result != 0 {
+        match (result as i32) != 0 {
             true => Some(Nil),
             false => None
         }
@@ -1109,7 +1109,8 @@ where
             // if list unification fails, or head can not be unified with current term,
             // return false early.
             // note: || is short-circuiting OR
-            if unsafe { PL_unify_list(list.term_ptr(), head.term_ptr(), tail.term_ptr()) == 0 }
+            if (unsafe { PL_unify_list(list.term_ptr(), head.term_ptr(), tail.term_ptr()) } as i32)
+                == 0
                 || head.unify(t).is_err()
             {
                 return false;
@@ -1125,7 +1126,7 @@ where
             frame2.close();
         }
 
-        let success = unsafe { PL_unify_nil(list.term_ptr()) != 0 };
+        let success = (unsafe { PL_unify_nil(list.term_ptr()) } as i32) != 0;
         frame.close();
 
         success
@@ -1147,15 +1148,16 @@ unsafe impl<T: TermGetable> TermGetable for Vec<T> {
         list.unify(term).unwrap();
         let mut success = true;
         loop {
-            if unsafe { PL_get_nil(list.term_ptr()) != 0 } {
+            if (unsafe { PL_get_nil(list.term_ptr()) } as i32) != 0 {
                 break;
             }
 
             let frame2 = frame.open_frame();
             let head = frame2.new_term_ref();
             let tail = frame2.new_term_ref();
-            success =
-                unsafe { PL_get_list(list.term_ptr(), head.term_ptr(), tail.term_ptr()) != 0 };
+            success = (unsafe { PL_get_list(list.term_ptr(), head.term_ptr(), tail.term_ptr()) }
+                as i32)
+                != 0;
 
             if !success {
                 break;

--- a/swipl/src/term/ser.rs
+++ b/swipl/src/term/ser.rs
@@ -225,9 +225,9 @@ impl<'a, C: QueryableContextType> serde::Serializer for Serializer<'a, C> {
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
         attempt_unify(&self.term, atom!("none"))
     }
-    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         if attempt(self.term.unify(functor!("some/1")))? {
             let [term] = attempt_opt(self.context.compound_terms(&self.term))?.expect("having just unified the functor some/1, retrieving its argument list should have been possible");
@@ -260,13 +260,13 @@ impl<'a, C: QueryableContextType> serde::Serializer for Serializer<'a, C> {
     ) -> Result<Self::Ok, Self::Error> {
         attempt_unify(&self.term, Atom::new(variant))
     }
-    fn serialize_newtype_struct<T: ?Sized>(
+    fn serialize_newtype_struct<T>(
         self,
         name: &'static str,
         value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         if name == ATOM_STRUCT_NAME {
             value.serialize(AtomEmitter(self.term))
@@ -283,7 +283,7 @@ impl<'a, C: QueryableContextType> serde::Serializer for Serializer<'a, C> {
             Err(Error::UnificationFailed)
         }
     }
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
@@ -291,7 +291,7 @@ impl<'a, C: QueryableContextType> serde::Serializer for Serializer<'a, C> {
         value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         if attempt(self.term.unify(Functor::new(variant, 1)))? {
             let [term] = attempt_opt(self.context.compound_terms(&self.term))?.expect("having just unified the functor with arity 1, retrieving its argument list should have been possible");
@@ -539,9 +539,9 @@ impl<'a> ser::Serializer for AtomEmitter<'a> {
         Err(Error::ValueNotOfExpectedType("string"))
     }
 
-    fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<Self::Ok, Self::Error>
+    fn serialize_some<T>(self, _value: &T) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(Error::ValueNotOfExpectedType("string"))
     }
@@ -563,18 +563,18 @@ impl<'a> ser::Serializer for AtomEmitter<'a> {
         Err(Error::ValueNotOfExpectedType("string"))
     }
 
-    fn serialize_newtype_struct<T: ?Sized>(
+    fn serialize_newtype_struct<T>(
         self,
         _name: &'static str,
         _value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(Error::ValueNotOfExpectedType("string"))
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
@@ -582,7 +582,7 @@ impl<'a> ser::Serializer for AtomEmitter<'a> {
         _value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(Error::ValueNotOfExpectedType("string"))
     }
@@ -647,9 +647,9 @@ impl<'a, C: QueryableContextType> ser::SerializeSeq for SerializeSeq<'a, C> {
 
     type Error = Error;
 
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         if let Some((head, tail)) = attempt_opt(self.context.unify_list_functor(&self.term))? {
             let inner_serializer =
@@ -680,9 +680,9 @@ impl<'a, C: QueryableContextType> ser::SerializeTuple for SerializeTuple<'a, C> 
 
     type Error = Error;
 
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         self.len -= 1;
         if self.len == 0 {
@@ -722,9 +722,9 @@ pub struct SerializeNamedTuple<'a, C: QueryableContextType> {
 }
 
 impl<'a, C: QueryableContextType> SerializeNamedTuple<'a, C> {
-    fn serialize_field_impl<T: ?Sized>(&mut self, value: &T) -> Result<(), Error>
+    fn serialize_field_impl<T>(&mut self, value: &T) -> Result<(), Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         self.pos += 1;
 
@@ -745,9 +745,9 @@ impl<'a, C: QueryableContextType> ser::SerializeTupleStruct for SerializeNamedTu
 
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         self.serialize_field_impl(value)
     }
@@ -762,9 +762,9 @@ impl<'a, C: QueryableContextType> ser::SerializeTupleVariant for SerializeNamedT
 
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         self.serialize_field_impl(value)
     }
@@ -813,9 +813,9 @@ impl<'a, C: QueryableContextType> ser::SerializeMap for SerializeMap<'a, C> {
 
     type Error = Error;
 
-    fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<(), Self::Error>
+    fn serialize_key<T>(&mut self, key: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         let serializer = KeyEmitter {
             key: &mut self.last_key,
@@ -825,9 +825,9 @@ impl<'a, C: QueryableContextType> ser::SerializeMap for SerializeMap<'a, C> {
         key.serialize(serializer)
     }
 
-    fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_value<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         let val_term = self.context.new_term_ref();
         let serializer =
@@ -854,13 +854,13 @@ impl<'a, C: QueryableContextType> ser::SerializeStruct for SerializeMap<'a, C> {
 
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(
+    fn serialize_field<T>(
         &mut self,
         key: &'static str,
         value: &T,
     ) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         let value_term = self.context.new_term_ref();
         let serializer = Serializer::new_with_config(
@@ -887,13 +887,13 @@ impl<'a, C: QueryableContextType> ser::SerializeStructVariant for SerializeMap<'
 
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(
+    fn serialize_field<T>(
         &mut self,
         key: &'static str,
         value: &T,
     ) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         let value_term = self.context.new_term_ref();
         let serializer = Serializer::new_with_config(
@@ -1048,9 +1048,9 @@ impl<'a> ser::Serializer for KeyEmitter<'a> {
         Err(Error::ValueNotOfExpectedType("key"))
     }
 
-    fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<Self::Ok, Self::Error>
+    fn serialize_some<T>(self, _value: &T) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(Error::ValueNotOfExpectedType("key"))
     }
@@ -1072,13 +1072,13 @@ impl<'a> ser::Serializer for KeyEmitter<'a> {
         Err(Error::ValueNotOfExpectedType("key"))
     }
 
-    fn serialize_newtype_struct<T: ?Sized>(
+    fn serialize_newtype_struct<T>(
         mut self,
         name: &'static str,
         value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         // could be an atom!
         if name == ATOM_STRUCT_NAME {
@@ -1089,7 +1089,7 @@ impl<'a> ser::Serializer for KeyEmitter<'a> {
         }
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
@@ -1097,7 +1097,7 @@ impl<'a> ser::Serializer for KeyEmitter<'a> {
         _value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(Error::ValueNotOfExpectedType("key"))
     }

--- a/swipl/src/text.rs
+++ b/swipl/src/text.rs
@@ -1,5 +1,6 @@
 //! Support for easy text extraction from prolog.
 use crate::fli;
+use crate::fli::FliSuccess;
 use crate::term::*;
 use crate::term_getable;
 
@@ -41,7 +42,7 @@ term_getable! {
                                                  flags) };
 
 
-        if (result as i32) == 0 {
+        if !result.is_success() {
             None
         }
         else {

--- a/swipl/src/text.rs
+++ b/swipl/src/text.rs
@@ -41,7 +41,7 @@ term_getable! {
                                                  flags) };
 
 
-        if result == 0 {
+        if (result as i32) == 0 {
             None
         }
         else {


### PR DESCRIPTION
_Update: folded the clippy cleanup onto `kzhrv:swi10-compat` (so this PR now includes SWI 10 compatibility + clippy fixes). Thanks @hoijnet for the improvements and clippy pass._

## SWI-Prolog 10 compatibility + clippy cleanup
This series makes swipl-rs build and work with SWI-Prolog 10.0.0 (Arch) while preserving SWI-Prolog 9.2.9 (nix) support, and fixes `cargo clippy --all-features -- -Dwarnings`.

## Key changes
- **SWI 10 autodetect in build.rs**: emits `cfg(swipl10)` when `info.version >= 100000`.
- **Portable FLI success checks**: introduce `FliSuccess`/`is_success()` so call sites work for:
  - SWI 9.x: FLI returns `c_int` (0/!=0)
  - SWI 10.x: many FLI calls return C11 `bool`
- **Dict integer keys**:
  - use `_PL_cons_small_int` for encoding integer keys
  - enforce the 56-bit limit explicitly (`2^56 - 1`)
  - avoid `PL_get_dict_key/3` for int keys (route int key lookups through `get_dict/3`) to prevent SWI 10 “invalid atom_t / bad tag” API aborts
  - add tests around small-int tagging/limits
- **init.rs foreign registration**: keep `pl_function_t` handling compatible across SWI 9/10 (SWI 10 defines `pl_function_t` as `void*`), using explicit `transmute` with targeted allow-lint.
- **Clippy fixes**: primarily lifetime elision/`<'_>` annotations, some idiomatic rewrites, and small mechanical cleanups.

## Notes / reviewer focus
- **context.rs lifetime annotations**: extensive but clippy-driven; would appreciate a careful look due to the crate’s intricate context lifetime model.
- **init.rs transmutes**: intentionally kept to preserve SWI 9+10 compatibility; type annotations added to make the coercions explicit.
 
## Verification
- `cargo clippy --all-features -- -Dwarnings` passes.
- TerminusDB builds against SWI-Prolog 10.0.0 with these changes.
- TerminusDB containers (unit tests enabled) built for both SWI versions:
  - `make docker-debug SWIPL_VERSION=9.2.9 SKIP_TESTS=false`
  - `make docker-debug SWIPL_VERSION=10.0.0 SKIP_TESTS=false`