### PR TITLE
Fix swipl-rs clippy warnings

### DIFF
--- a/examples/swipl-module-example/src/lib.rs
+++ b/examples/swipl-module-example/src/lib.rs
@@ -101,7 +101,7 @@ predicates! {
     semidet fn unify_with_wrapped_blob(_context, term, num_term) {
         let num: u64 = num_term.get()?;
         let arc = Arc::new(Inner { num });
-        term.unify(&MooMoo(arc))
+        term.unify(MooMoo(arc))
     }
 
     semidet fn moomoo_num(_context, moo_term, num_term) {

--- a/swipl-fli/Cargo.toml
+++ b/swipl-fli/Cargo.toml
@@ -9,6 +9,12 @@ description = "Low-level bindings to the SWI-Prolog Foreign Language Interface"
 repository = "https://github.com/terminusdb-labs/swipl-rs/"
 documentation = "https://terminusdb-labs.github.io/swipl-rs/swipl_fli/"
 
+[features]
+default = []
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(swipl10)"] }
+
 [dependencies]
 [build-dependencies]
 bindgen = "0.69.4"

--- a/swipl-fli/build.rs
+++ b/swipl-fli/build.rs
@@ -10,6 +10,12 @@ fn main() {
     println!("cargo:rerun-if-changed=c/wrapper.h");
     println!("cargo:rerun-if-env-changed=SWIPL");
 
+    // Autodetect SWI-Prolog 10.x (version >= 100000)
+    // SWI-Prolog 10.x uses C11 bool for FLI return types
+    if info.version >= 100000 {
+        println!("cargo:rustc-cfg=swipl10");
+    }
+
     let bindings = bindgen::Builder::default()
         .header("c/wrapper.h")
         .clang_arg(format!("-I{}", info.header_dir))

--- a/swipl-fli/src/lib.rs
+++ b/swipl-fli/src/lib.rs
@@ -25,6 +25,7 @@ pub type FliResult = ::std::os::raw::c_int;
 ///
 /// This provides a portable way to check if an FLI function succeeded,
 /// regardless of whether it returns `c_int` (swipl 9.x) or `bool` (swipl 10.x).
+#[allow(clippy::wrong_self_convention)]
 pub trait FliSuccess {
     /// Returns `true` if the FLI call succeeded.
     fn is_success(self) -> bool;

--- a/swipl-macros/src/blob.rs
+++ b/swipl-macros/src/blob.rs
@@ -18,7 +18,7 @@ pub fn arc_blob_macro(
 
     let name_lit = attr_def.name;
     let name = name_lit.value();
-    let mut name_bytes = Vec::with_capacity(name.as_bytes().len() + 1);
+    let mut name_bytes = Vec::with_capacity(name.len() + 1);
     name_bytes.extend_from_slice(name.as_bytes());
     name_bytes.push(0);
     let name_bytes_lit = LitByteStr::new(&name_bytes, Span::call_site());
@@ -153,7 +153,7 @@ pub fn wrapped_arc_blob_macro(item: proc_macro::TokenStream) -> proc_macro::Toke
     let item_def = parse_macro_input!(item as WrappedArcBlobItem);
     let name_lit = item_def.name;
     let name = name_lit.value();
-    let mut name_bytes = Vec::with_capacity(name.as_bytes().len() + 1);
+    let mut name_bytes = Vec::with_capacity(name.len() + 1);
     name_bytes.extend_from_slice(name.as_bytes());
     name_bytes.push(0);
     let name_bytes_lit = LitByteStr::new(&name_bytes, Span::call_site());
@@ -338,7 +338,7 @@ pub fn clone_blob_macro(
 
     let name_lit = attr_def.name;
     let name = name_lit.value();
-    let mut name_bytes = Vec::with_capacity(name.as_bytes().len() + 1);
+    let mut name_bytes = Vec::with_capacity(name.len() + 1);
     name_bytes.extend_from_slice(name.as_bytes());
     name_bytes.push(0);
     let name_bytes_lit = LitByteStr::new(&name_bytes, Span::call_site());

--- a/swipl-macros/src/lib.rs
+++ b/swipl-macros/src/lib.rs
@@ -177,10 +177,10 @@ pub fn pred(stream: TokenStream) -> TokenStream {
 /// You can return from this block in three ways:
 /// - Return an exception or failure. The predicate will error or fail accordingly and the call block will not be invoked.
 /// - Return `None`. The call block will also not be invoked, but the
-/// predicate will return success. This is useful to handle predicate
-/// inputs which allow your predicate to behave in a semidet manner.
+///   predicate will return success. This is useful to handle predicate
+///   inputs which allow your predicate to behave in a semidet manner.
 /// - Return `Some(object)`. This returns a state object for use in
-/// the call block. After this, the call block will be invoked.
+///   the call block. After this, the call block will be invoked.
 ///
 /// ## Call
 /// The call block is called each time the next result is required from this predicate. This happens on the first call to this predicate (except if the setup returned early as described above), and subsequently upon backtracking. The call block is given a mutable borrow of the state object, and is therefore able to both inspect and modify it.

--- a/swipl-macros/src/predicate.rs
+++ b/swipl-macros/src/predicate.rs
@@ -74,6 +74,7 @@ impl Parse for AttributedForeignPredicateDefinition {
     }
 }
 
+#[allow(dead_code)]
 trait ForeignPredicateDefinitionImpl {
     fn generate_definition(&self) -> TokenStream;
     fn generate_trampoline(&self) -> (Ident, TokenStream);

--- a/swipl/Cargo.toml
+++ b/swipl/Cargo.toml
@@ -20,5 +20,9 @@ convert_case = "0.6"
 num_enum = "0.7.1"
 either = "1.9.0"
 
+[features]
+default = []
+gc_debug = []  # Enable GC debugging instrumentation
+
 [dev-dependencies]
 serde = {version="1.0", features=["derive"]}

--- a/swipl/src/atom.rs
+++ b/swipl/src/atom.rs
@@ -116,9 +116,9 @@ impl Atom {
     }
 }
 
-impl ToString for Atom {
-    fn to_string(&self) -> String {
-        self.name()
+impl std::fmt::Display for Atom {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name())
     }
 }
 

--- a/swipl/src/atom.rs
+++ b/swipl/src/atom.rs
@@ -187,11 +187,7 @@ where
 
 term_getable! {
     (Atom, "atom", term) => {
-        match term.get_atom(|a| a.cloned()) {
-            Ok(r) => r,
-            // ignore this error - it'll be picked up again by the wrapper
-            Err(_) => None
-        }
+        term.get_atom(|a| a.cloned()).unwrap_or_default()
     }
 }
 
@@ -404,11 +400,7 @@ where
 
 term_getable! {
     (Atomable<'static>, "atom", term) => {
-        match get_atomable(term, |a|a.map(|a|a.owned())) {
-            Ok(r) => r,
-            // ignore error - it'll be picked up in the wrapper
-            Err(_) => None
-        }
+        get_atomable(term, |a|a.map(|a|a.owned())).unwrap_or_default()
     }
 }
 

--- a/swipl/src/atom.rs
+++ b/swipl/src/atom.rs
@@ -15,6 +15,7 @@
 use super::context::*;
 use super::engine::*;
 use super::fli::*;
+use super::fli::FliSuccess;
 use super::init::*;
 use super::result::*;
 use super::term::*;
@@ -148,7 +149,7 @@ unifiable! {
     (self:Atom, term) => {
         let result = unsafe { PL_unify_atom(term.term_ptr(), self.atom) };
 
-        result != 0
+        result.is_success()
     }
 }
 
@@ -169,7 +170,7 @@ where
         return Err(PrologError::Exception);
     }
 
-    let arg = if result == 0 {
+    let arg = if !result.is_success() {
         None
     } else {
         let atom = unsafe { Atom::wrap(atom) };
@@ -352,7 +353,7 @@ unifiable! {
             )
         };
 
-        result != 0
+        result.is_success()
     }
 }
 
@@ -383,7 +384,7 @@ where
         return Err(PrologError::Exception);
     }
 
-    let arg = if result == 0 {
+    let arg = if !result.is_success() {
         None
     } else {
         let swipl_string_ref = unsafe { std::slice::from_raw_parts(ptr as *const u8, len) };

--- a/swipl/src/atom.rs
+++ b/swipl/src/atom.rs
@@ -208,7 +208,7 @@ pub enum Atomable<'a> {
 }
 
 impl<'a> From<&'a str> for Atomable<'a> {
-    fn from(s: &str) -> Atomable {
+    fn from(s: &str) -> Atomable<'_> {
         Atomable::Str(s)
     }
 }
@@ -277,7 +277,7 @@ impl<'a> IntoAtom for Atomable<'a> {
     }
 }
 
-impl<'a> IntoAtom for &'a str {
+impl IntoAtom for &str {
     fn into_atom(self) -> Atom {
         Atom::new(self)
     }
@@ -330,7 +330,7 @@ impl<'a> AsAtom for Atomable<'a> {
     }
 }
 
-impl<'a> AsAtom for &'a str {
+impl AsAtom for &str {
     fn as_atom(&self) -> Atom {
         self.into_atom()
     }

--- a/swipl/src/blob.rs
+++ b/swipl/src/blob.rs
@@ -397,7 +397,7 @@ pub unsafe fn get_arc_from_term<T>(
 
     let mut blob_type = std::ptr::null_mut();
     if !fli::PL_is_blob(term.term_ptr(), &mut blob_type).is_success()
-        || blob_definition as *const fli::PL_blob_t != blob_type
+        || !std::ptr::eq(blob_definition as *const fli::PL_blob_t, blob_type)
     {
         return None;
     }
@@ -435,7 +435,7 @@ pub unsafe fn get_cloned_from_term<T: Clone + Sized + Unpin>(
 
     let mut blob_type = std::ptr::null_mut();
     if !fli::PL_is_blob(term.term_ptr(), &mut blob_type).is_success()
-        || blob_definition as *const fli::PL_blob_t != blob_type
+        || !std::ptr::eq(blob_definition as *const fli::PL_blob_t, blob_type)
     {
         return None;
     }

--- a/swipl/src/blob.rs
+++ b/swipl/src/blob.rs
@@ -220,6 +220,7 @@ use std::os::raw::{c_int, c_void};
 use std::sync::Arc;
 
 use crate::fli;
+use crate::fli::FliSuccess;
 use crate::stream::*;
 use crate::term::*;
 
@@ -346,7 +347,7 @@ pub unsafe fn unify_with_arc<T>(
         blob_definition as *const fli::PL_blob_t as *mut fli::PL_blob_t,
     );
 
-    result != 0
+    result.is_success()
 }
 
 /// Unify the term with the given Cloneable, using the given blob
@@ -372,7 +373,7 @@ pub unsafe fn unify_with_cloneable<T: Clone + Sized + Unpin>(
         blob_definition as *const fli::PL_blob_t as *mut fli::PL_blob_t,
     );
 
-    if result != 0 {
+    if result.is_success() {
         std::mem::forget(cloned);
         true
     } else {
@@ -395,7 +396,7 @@ pub unsafe fn get_arc_from_term<T>(
     term.assert_term_handling_possible();
 
     let mut blob_type = std::ptr::null_mut();
-    if fli::PL_is_blob(term.term_ptr(), &mut blob_type) == 0
+    if !fli::PL_is_blob(term.term_ptr(), &mut blob_type).is_success()
         || blob_definition as *const fli::PL_blob_t != blob_type
     {
         return None;
@@ -409,7 +410,7 @@ pub unsafe fn get_arc_from_term<T>(
         std::ptr::null_mut(),
     );
 
-    if result == 0 {
+    if !result.is_success() {
         None
     } else {
         Arc::increment_strong_count(data);
@@ -433,7 +434,7 @@ pub unsafe fn get_cloned_from_term<T: Clone + Sized + Unpin>(
     term.assert_term_handling_possible();
 
     let mut blob_type = std::ptr::null_mut();
-    if fli::PL_is_blob(term.term_ptr(), &mut blob_type) == 0
+    if !fli::PL_is_blob(term.term_ptr(), &mut blob_type).is_success()
         || blob_definition as *const fli::PL_blob_t != blob_type
     {
         return None;
@@ -447,7 +448,7 @@ pub unsafe fn get_cloned_from_term<T: Clone + Sized + Unpin>(
         std::ptr::null_mut(),
     );
 
-    if result == 0 {
+    if !result.is_success() {
         None
     } else {
         let cloned = (*data).clone();

--- a/swipl/src/callable.rs
+++ b/swipl/src/callable.rs
@@ -67,7 +67,7 @@ impl<const N: usize> Callable<N> for LazyCallablePredicate<N> {
     }
 }
 
-impl<'a, const N: usize> Callable<N> for &'a LazyCallablePredicate<N> {
+impl<const N: usize> Callable<N> for &LazyCallablePredicate<N> {
     type ContextType = OpenQuery;
 
     fn open<'b, C: ContextType>(

--- a/swipl/src/context.rs
+++ b/swipl/src/context.rs
@@ -57,6 +57,7 @@ use super::atom::*;
 use super::callable::*;
 use super::engine::*;
 use super::fli::*;
+use super::fli::FliSuccess;
 use super::module::*;
 use super::result::*;
 use super::stream::*;
@@ -76,7 +77,7 @@ pub(crate) unsafe fn with_cleared_exception<R>(f: impl FnOnce() -> R) -> R {
     let error_term_ref = pl_default_exception();
     if error_term_ref != 0 {
         let backup_term_ref = PL_new_term_ref();
-        assert!(PL_unify(backup_term_ref, error_term_ref) != 0);
+        assert!(PL_unify(backup_term_ref, error_term_ref).is_success());
         PL_clear_exception();
         let result = f();
         PL_raise_exception(backup_term_ref);
@@ -117,7 +118,7 @@ impl<'a> ExceptionTerm<'a> {
     ) -> R {
         ctx.assert_activated();
         let backup_term_ref = PL_new_term_ref();
-        assert!(PL_unify(backup_term_ref, self.0.term_ptr()) != 0);
+        assert!(PL_unify(backup_term_ref, self.0.term_ptr()).is_success());
         let backup_term = Term::new(backup_term_ref, ctx.as_term_origin());
         PL_clear_exception();
 
@@ -958,7 +959,7 @@ impl<'a, T: QueryableContextType> Context<'a, T> {
 
         let mut size = 0;
         if unsafe {
-            PL_get_compound_name_arity(compound.term_ptr(), std::ptr::null_mut(), &mut size) != 1
+            !PL_get_compound_name_arity(compound.term_ptr(), std::ptr::null_mut(), &mut size).is_success()
         } {
             return Err(PrologError::Failure);
         }
@@ -969,7 +970,9 @@ impl<'a, T: QueryableContextType> Context<'a, T> {
         let terms: [Term; N] = self.new_term_refs();
         for (i, term) in terms.iter().enumerate() {
             unsafe {
-                assert!(PL_get_arg((i + 1) as i32, compound.term_ptr(), term.term_ptr()) == 1);
+                assert!(
+                    PL_get_arg((i + 1) as i32, compound.term_ptr(), term.term_ptr()).is_success()
+                );
             }
         }
 
@@ -987,7 +990,7 @@ impl<'a, T: QueryableContextType> Context<'a, T> {
 
         let mut size = 0;
         if unsafe {
-            PL_get_compound_name_arity(compound.term_ptr(), std::ptr::null_mut(), &mut size) != 1
+            !PL_get_compound_name_arity(compound.term_ptr(), std::ptr::null_mut(), &mut size).is_success()
         } {
             return Err(PrologError::Failure);
         }
@@ -995,7 +998,9 @@ impl<'a, T: QueryableContextType> Context<'a, T> {
         let terms = self.new_term_refs_vec(size as usize);
         for (i, term) in terms.iter().enumerate() {
             unsafe {
-                assert!(PL_get_arg((i + 1) as i32, compound.term_ptr(), term.term_ptr()) == 1);
+                assert!(
+                    PL_get_arg((i + 1) as i32, compound.term_ptr(), term.term_ptr()).is_success()
+                );
             }
         }
 
@@ -1018,7 +1023,7 @@ impl<'a, T: QueryableContextType> Context<'a, T> {
 
         let mut size = 0;
         if unsafe {
-            PL_get_compound_name_arity(compound.term_ptr(), std::ptr::null_mut(), &mut size) != 1
+            !PL_get_compound_name_arity(compound.term_ptr(), std::ptr::null_mut(), &mut size).is_success()
         } {
             return Err(PrologError::Failure);
         }
@@ -1029,7 +1034,9 @@ impl<'a, T: QueryableContextType> Context<'a, T> {
         let terms = self.new_term_refs_vec(count);
         for (i, term) in terms.iter().enumerate() {
             unsafe {
-                assert!(PL_get_arg((i + 1) as i32, compound.term_ptr(), term.term_ptr()) == 1);
+                assert!(
+                    PL_get_arg((i + 1) as i32, compound.term_ptr(), term.term_ptr()).is_success()
+                );
             }
         }
 
@@ -1076,8 +1083,8 @@ impl<'a, T: QueryableContextType> Context<'a, T> {
         term: &Term,
     ) -> Result<(Term<'b>, Term<'b>), PrologError> {
         let [head, tail] = self.new_term_refs();
-        match unsafe { PL_unify_list(term.term_ptr(), head.term_ptr(), tail.term_ptr()) } {
-            0 => {
+        match unsafe { PL_unify_list(term.term_ptr(), head.term_ptr(), tail.term_ptr()) }.is_success() {
+            false => {
                 unsafe {
                     head.reset();
                 }
@@ -1112,8 +1119,7 @@ impl<'a, 'b, CT: QueryableContextType> Iterator for TermListIterator<'a, 'b, CT>
     fn next(&mut self) -> Option<Term<'a>> {
         let head = self.context.new_term_ref();
         let tail = self.context.new_term_ref();
-        let success =
-            unsafe { PL_get_list(self.cur.term_ptr(), head.term_ptr(), tail.term_ptr()) != 0 };
+        let success = unsafe { PL_get_list(self.cur.term_ptr(), head.term_ptr(), tail.term_ptr()) }.is_success();
 
         if success {
             self.cur = tail;

--- a/swipl/src/context.rs
+++ b/swipl/src/context.rs
@@ -370,7 +370,7 @@ pub unsafe trait ContextType {}
 /// # use swipl::prelude::*;
 /// let engine = Engine::new();
 /// let activation = engine.activate();
-
+///
 /// let context: Context<ActivatedEngine> = activation.into();
 /// // Note: Context<_> would also work as a type annotation
 /// ```

--- a/swipl/src/dict.rs
+++ b/swipl/src/dict.rs
@@ -87,7 +87,7 @@ pub trait IntoKey {
     fn atom_ptr(self) -> (fli::atom_t, Option<Atom>);
 }
 
-impl<'a, A: AsAtom + ?Sized> IntoKey for &'a A {
+impl<A: AsAtom + ?Sized> IntoKey for &A {
     fn atom_ptr(self) -> (fli::atom_t, Option<Atom>) {
         self.as_atom_ptr()
     }
@@ -126,7 +126,6 @@ impl IntoKey for u64 {
 ///     bar: "hello"
 /// }
 /// ```
-
 pub struct DictBuilder<'a> {
     tag: DictTag<'a>,
     entries: HashMap<Key, Option<Box<dyn TermPutable + 'a>>>,

--- a/swipl/src/engine.rs
+++ b/swipl/src/engine.rs
@@ -125,7 +125,7 @@ impl Engine {
         is_engine_active(self.engine_ptr)
     }
 
-    pub(crate) unsafe fn set_activated(&self) -> EngineActivation {
+    pub(crate) unsafe fn set_activated(&self) -> EngineActivation<'_> {
         if self
             .active
             .compare_exchange(
@@ -150,7 +150,7 @@ impl Engine {
     /// This will panic if an engine is already active on this
     /// thread. Otherwise, it'll return an `EngineActivation` whose
     /// lifetime is bound to this engine.
-    pub fn activate(&self) -> EngineActivation {
+    pub fn activate(&self) -> EngineActivation<'_> {
         if Self::some_engine_active() {
             panic!("tried to activate engine on a thread that already has an active engine");
         }

--- a/swipl/src/functor.rs
+++ b/swipl/src/functor.rs
@@ -10,6 +10,7 @@ use super::atom::*;
 use super::consts::*;
 use super::engine::*;
 use super::fli::*;
+use super::fli::FliSuccess;
 use super::term::*;
 
 use std::convert::TryInto;
@@ -105,7 +106,7 @@ unifiable! {
     (self: Functor, term) => {
         let result = unsafe {PL_unify_compound(term.term_ptr(), self.functor)};
 
-        result != 0
+        result.is_success()
     }
 }
 
@@ -114,7 +115,7 @@ term_getable! {
         let mut functor = 0;
         let result = unsafe { PL_get_functor(term.term_ptr(), &mut functor) };
 
-        if result == 0 {
+        if !result.is_success() {
             None
         }
         else {

--- a/swipl/src/init.rs
+++ b/swipl/src/init.rs
@@ -194,8 +194,11 @@ pub unsafe fn register_foreign_in_module(
         flags |= PL_FA_NONDETERMINISTIC;
     }
 
-    // an unfortunate need for transmute to make the fli eat the pointer
-    let converted_function_ptr = std::mem::transmute(function_ptr);
+    // Convert to whatever pl_function_t is for the active SWI-Prolog.
+    //
+    // SWI-Prolog 10 defines pl_function_t as void*; older versions used a function pointer type.
+    // We keep a single call site by transmuting into the bindgen-generated type.
+    let converted_function_ptr: pl_function_t = std::mem::transmute(function_ptr);
     let c_module_ptr = c_module
         .as_ref()
         .map(|m| m.as_ptr())

--- a/swipl/src/init.rs
+++ b/swipl/src/init.rs
@@ -10,6 +10,7 @@
 
 use crate::engine::*;
 use crate::fli::*;
+use crate::fli::FliSuccess;
 
 use lazy_static::*;
 use std::convert::TryInto;
@@ -30,7 +31,7 @@ pub fn activate_main() -> EngineActivation<'static> {
 
 /// Check if SWI-Prolog has been initialized.
 pub fn is_swipl_initialized() -> bool {
-    unsafe { PL_is_initialised(std::ptr::null_mut(), std::ptr::null_mut()) != 0 }
+    unsafe { PL_is_initialised(std::ptr::null_mut(), std::ptr::null_mut()) }.is_success()
 }
 
 /// Panic if SWI-Prolog has not been initialized.
@@ -96,7 +97,7 @@ pub fn initialize_swipl_with_state(state: &'static [u8]) -> Option<EngineActivat
     // https://www.swi-prolog.org/pldoc/doc_for?object=c(%27PL_set_resource_db_mem%27)
     let result = unsafe { PL_set_resource_db_mem(state.as_ptr(), state.len()) };
 
-    if result != TRUE as i32 {
+    if !result.is_success() {
         return None;
     }
 
@@ -204,8 +205,8 @@ pub unsafe fn register_foreign_in_module(
         c_module_ptr,
         c_name.as_ptr(),
         arity as c_int,
-        Some(converted_function_ptr),
+        converted_function_ptr,
         flags.try_into().unwrap(),
         c_meta.map(|m| m.as_ptr()).unwrap_or_else(std::ptr::null),
-    ) == 1
+    ).is_success()
 }

--- a/swipl/src/record.rs
+++ b/swipl/src/record.rs
@@ -6,6 +6,7 @@
 //! automatically on drop of a wrapper object.
 
 use super::fli;
+use super::fli::FliSuccess;
 use super::result::*;
 use super::term::*;
 use crate::{term_getable, term_putable, unifiable};
@@ -33,7 +34,7 @@ impl Record {
     /// Copy the recorded term into the given term reference.
     pub fn recorded(&self, term: &Term) -> PrologResult<()> {
         term.assert_term_handling_possible();
-        unsafe { into_prolog_result(fli::PL_recorded(self.record, term.term_ptr()) != 0) }
+        unsafe { into_prolog_result(fli::PL_recorded(self.record, term.term_ptr()).is_success()) }
     }
 }
 
@@ -77,7 +78,7 @@ unifiable! {
             let result = fli::PL_unify(term.term_ptr(), extra_term);
             fli::PL_reset_term_refs(extra_term);
 
-            result != 0
+            result.is_success()
         }
     }
 }

--- a/swipl/src/stream.rs
+++ b/swipl/src/stream.rs
@@ -160,7 +160,7 @@ impl<'a> Write for WritablePrologStream<'a> {
 
         match (result, error) {
             (0, 0) => Ok(()),
-            _ => Err(io::Error::new(io::ErrorKind::Other, "prolog flush failed")),
+            _ => Err(io::Error::other("prolog flush failed")),
         }
     }
 }
@@ -180,7 +180,7 @@ impl Write for PrologStream {
         }
         match (result, error) {
             (0, 0) => Ok(()),
-            _ => Err(io::Error::new(io::ErrorKind::Other, "prolog flush failed")),
+            _ => Err(io::Error::other("prolog flush failed")),
         }
     }
 }

--- a/swipl/src/stream.rs
+++ b/swipl/src/stream.rs
@@ -11,6 +11,7 @@ use num_enum::FromPrimitive;
 use crate::engine::*;
 use crate::term::*;
 use crate::{fli, term_getable};
+use crate::fli::FliSuccess;
 
 /// A stream from prolog, used in blob writers.
 pub struct PrologStream {
@@ -72,7 +73,7 @@ term_getable! {
     // origin.
     (WritablePrologStream<'a>, term) => {
         let mut stream: *mut fli::IOSTREAM = std::ptr::null_mut();
-        if unsafe { fli::PL_get_stream(term.term_ptr(), &mut stream, fli::SH_OUTPUT|fli::SH_UNLOCKED|fli::SH_NOPAIR) } != 0 {
+        if unsafe { fli::PL_get_stream(term.term_ptr(), &mut stream, fli::SH_OUTPUT|fli::SH_UNLOCKED|fli::SH_NOPAIR) }.is_success() {
             Some(unsafe {WritablePrologStream::new(stream) })
         }
         else {
@@ -273,7 +274,7 @@ term_getable! {
     // origin.
     (ReadablePrologStream<'a>, term) => {
         let mut stream: *mut fli::IOSTREAM = std::ptr::null_mut();
-        if unsafe { fli::PL_get_stream(term.term_ptr(), &mut stream, fli::SH_INPUT|fli::SH_UNLOCKED|fli::SH_NOPAIR) } != 0 {
+        if unsafe { fli::PL_get_stream(term.term_ptr(), &mut stream, fli::SH_INPUT|fli::SH_UNLOCKED|fli::SH_NOPAIR) }.is_success() {
             Some(unsafe {ReadablePrologStream::new(stream) })
         }
         else {

--- a/swipl/src/term/mod.rs
+++ b/swipl/src/term/mod.rs
@@ -993,11 +993,7 @@ unifiable! {
 
 term_getable! {
     (String, "string", term) => {
-        match term.get_str(|s|s.map(|s|s.to_owned())) {
-            Ok(r) => r,
-            // ignore error - it'll be picked up by the wrapper
-            Err(_) => None
-        }
+        term.get_str(|s|s.map(|s|s.to_owned())).unwrap_or_default()
     }
 }
 

--- a/swipl/src/term/mod.rs
+++ b/swipl/src/term/mod.rs
@@ -33,6 +33,7 @@ use super::atom::*;
 use super::context::*;
 use super::engine::*;
 use super::fli::*;
+use super::fli::FliSuccess;
 use super::record::*;
 use super::result::*;
 use std::cmp::{Ordering, PartialOrd};
@@ -120,25 +121,25 @@ impl<'a> Term<'a> {
     /// Returns true if this term reference holds a variable.
     pub fn is_var(&self) -> bool {
         self.assert_term_handling_possible();
-        unsafe { PL_is_variable(self.term) != 0 }
+        unsafe { PL_is_variable(self.term) }.is_success()
     }
 
     /// Returns true if this term reference holds an atom.
     pub fn is_atom(&self) -> bool {
         self.assert_term_handling_possible();
-        unsafe { PL_is_atom(self.term) != 0 }
+        unsafe { PL_is_atom(self.term) }.is_success()
     }
 
     /// Returns true if this term reference holds a string.
     pub fn is_string(&self) -> bool {
         self.assert_term_handling_possible();
-        unsafe { PL_is_string(self.term) != 0 }
+        unsafe { PL_is_string(self.term) }.is_success()
     }
 
     /// Returns true if this term reference holds an integer.
     pub fn is_integer(&self) -> bool {
         self.assert_term_handling_possible();
-        unsafe { PL_is_integer(self.term) != 0 }
+        unsafe { PL_is_integer(self.term) }.is_success()
     }
 
     /// Reset terms created after this term, including this term itself.
@@ -210,7 +211,7 @@ impl<'a> Term<'a> {
 
         let arg = unsafe { Term::new(arg_ref, self.origin.clone()) };
         let mut result2 = Err(PrologError::Failure);
-        if result != 0 {
+        if result.is_success() {
             result2 = arg.unify(unifiable);
         }
 
@@ -321,7 +322,7 @@ impl<'a> Term<'a> {
 
         let arg = unsafe { Term::new(arg_ref, self.origin.clone()) };
         let mut result2 = Err(PrologError::Failure);
-        if result != 0 {
+        if result.is_success() {
             result2 = arg.get();
         }
 
@@ -356,7 +357,7 @@ impl<'a> Term<'a> {
         }
 
         let arg = unsafe { Term::new(arg_ref, self.origin.clone()) };
-        let result2 = if result != 0 {
+        let result2 = if result.is_success() {
             arg.get_ex()
         } else {
             let context = unsafe { unmanaged_engine_context() };
@@ -393,7 +394,7 @@ impl<'a> Term<'a> {
             return Err(PrologError::Exception);
         }
 
-        let arg = if result == 0 {
+        let arg = if !result.is_success() {
             None
         } else {
             let swipl_string_ref = unsafe { std::slice::from_raw_parts(ptr as *const u8, len) };
@@ -442,7 +443,7 @@ impl<'a> Term<'a> {
             return Err(PrologError::Exception);
         }
 
-        let arg = if result == 0 {
+        let arg = if !result.is_success() {
             None
         } else {
             let swipl_string_ref = unsafe { std::slice::from_raw_parts(ptr as *const u8, len) };
@@ -779,7 +780,7 @@ unifiable! {
         let result = unsafe { PL_unify(self.term, term.term) };
 
         // TODO we should actually properly test for an exception here.
-        result != 0
+        result.is_success()
     }
 }
 
@@ -801,7 +802,7 @@ unifiable! {
         };
         let result = unsafe { PL_unify_bool(term.term, num) };
 
-        result != 0
+        result.is_success()
     }
 }
 
@@ -809,7 +810,7 @@ term_getable! {
     (bool, term) => {
         let mut out = 0;
         let result = unsafe { PL_get_bool(term.term, &mut out) };
-        if result == 0 {
+        if !result.is_success() {
             None
         }
         else {
@@ -857,7 +858,7 @@ unifiable! {
                 false
             }
             else {
-                result != 0
+                result.is_success()
             }
         })}
     }
@@ -865,7 +866,7 @@ unifiable! {
 
 term_getable! {
     (u64, "integer", term) => {
-        if unsafe { PL_is_integer(term.term) == 0 } {
+        if !unsafe { PL_is_integer(term.term) }.is_success() {
             return None;
         }
 
@@ -892,7 +893,7 @@ term_getable! {
                 error_term.reset();
                 None
             }
-            else if result == 0 {
+            else if !result.is_success() {
                 None
             }
             else {
@@ -912,7 +913,7 @@ unifiable! {
     (self:i64, term) => {
         let result = unsafe { PL_unify_int64(term.term, *self) };
 
-        result != 0
+        result.is_success()
     }
 }
 
@@ -920,7 +921,7 @@ term_getable! {
     (i64, "integer", term) => {
         let mut out = 0;
         let result = unsafe { PL_get_int64(term.term, &mut out) };
-        if result == 0 {
+        if !result.is_success() {
             None
         }
         else {
@@ -939,7 +940,7 @@ unifiable! {
     (self:f64, term) => {
         let result = unsafe { PL_unify_float(term.term, *self) };
 
-        result != 0
+        result.is_success()
     }
 }
 
@@ -947,7 +948,7 @@ term_getable! {
     (f64, "float", term) => {
         let mut out = 0.0;
         let result = unsafe { PL_get_float(term.term, &mut out) };
-        if result == 0 {
+        if !result.is_success() {
             None
         }
         else {
@@ -972,7 +973,7 @@ unifiable! {
         )
         };
 
-        result != 0
+        result.is_success()
     }
 }
 
@@ -986,7 +987,7 @@ unifiable! {
         )
         };
 
-        result != 0
+        result.is_success()
     }
 }
 
@@ -1028,7 +1029,7 @@ unifiable! {
     (self: &[u8], term) => {
         let result = unsafe { PL_unify_string_nchars(term.term_ptr(), self.len(), self.as_ptr() as *const std::os::raw::c_char) };
 
-        result != 0
+        result.is_success()
     }
 }
 
@@ -1037,7 +1038,7 @@ term_getable! {
         let mut string_ptr = std::ptr::null_mut();
         let mut len = 0;
         let result = unsafe { PL_get_string(term.term_ptr(), &mut string_ptr, &mut len) };
-        if result == 0 {
+        if !result.is_success() {
             return None;
         }
 
@@ -1062,7 +1063,7 @@ unifiable! {
     (self:Nil, term) => {
         let result = unsafe { PL_unify_nil(term.term_ptr()) };
 
-        result != 0
+        result.is_success()
     }
 }
 
@@ -1070,7 +1071,7 @@ term_getable! {
     (Nil, "list", term) => {
         let result = unsafe { PL_get_nil(term.term_ptr()) };
 
-        match result != 0 {
+        match result.is_success() {
             true => Some(Nil),
             false => None
         }
@@ -1109,7 +1110,7 @@ where
             // if list unification fails, or head can not be unified with current term,
             // return false early.
             // note: || is short-circuiting OR
-            if unsafe { PL_unify_list(list.term_ptr(), head.term_ptr(), tail.term_ptr()) == 0 }
+            if !unsafe { PL_unify_list(list.term_ptr(), head.term_ptr(), tail.term_ptr()) }.is_success()
                 || head.unify(t).is_err()
             {
                 return false;
@@ -1125,7 +1126,7 @@ where
             frame2.close();
         }
 
-        let success = unsafe { PL_unify_nil(list.term_ptr()) != 0 };
+        let success = unsafe { PL_unify_nil(list.term_ptr()) }.is_success();
         frame.close();
 
         success
@@ -1147,15 +1148,14 @@ unsafe impl<T: TermGetable> TermGetable for Vec<T> {
         list.unify(term).unwrap();
         let mut success = true;
         loop {
-            if unsafe { PL_get_nil(list.term_ptr()) != 0 } {
+            if unsafe { PL_get_nil(list.term_ptr()) }.is_success() {
                 break;
             }
 
             let frame2 = frame.open_frame();
             let head = frame2.new_term_ref();
             let tail = frame2.new_term_ref();
-            success =
-                unsafe { PL_get_list(list.term_ptr(), head.term_ptr(), tail.term_ptr()) != 0 };
+            success = unsafe { PL_get_list(list.term_ptr(), head.term_ptr(), tail.term_ptr()) }.is_success();
 
             if !success {
                 break;

--- a/swipl/src/term/ser.rs
+++ b/swipl/src/term/ser.rs
@@ -225,9 +225,9 @@ impl<'a, C: QueryableContextType> serde::Serializer for Serializer<'a, C> {
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
         attempt_unify(&self.term, atom!("none"))
     }
-    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         if attempt(self.term.unify(functor!("some/1")))? {
             let [term] = attempt_opt(self.context.compound_terms(&self.term))?.expect("having just unified the functor some/1, retrieving its argument list should have been possible");
@@ -260,13 +260,13 @@ impl<'a, C: QueryableContextType> serde::Serializer for Serializer<'a, C> {
     ) -> Result<Self::Ok, Self::Error> {
         attempt_unify(&self.term, Atom::new(variant))
     }
-    fn serialize_newtype_struct<T: ?Sized>(
+    fn serialize_newtype_struct<T>(
         self,
         name: &'static str,
         value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         if name == ATOM_STRUCT_NAME {
             value.serialize(AtomEmitter(self.term))
@@ -283,7 +283,7 @@ impl<'a, C: QueryableContextType> serde::Serializer for Serializer<'a, C> {
             Err(Error::UnificationFailed)
         }
     }
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
@@ -291,7 +291,7 @@ impl<'a, C: QueryableContextType> serde::Serializer for Serializer<'a, C> {
         value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         if attempt(self.term.unify(Functor::new(variant, 1)))? {
             let [term] = attempt_opt(self.context.compound_terms(&self.term))?.expect("having just unified the functor with arity 1, retrieving its argument list should have been possible");
@@ -539,9 +539,9 @@ impl<'a> ser::Serializer for AtomEmitter<'a> {
         Err(Error::ValueNotOfExpectedType("string"))
     }
 
-    fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<Self::Ok, Self::Error>
+    fn serialize_some<T>(self, _value: &T) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(Error::ValueNotOfExpectedType("string"))
     }
@@ -563,18 +563,18 @@ impl<'a> ser::Serializer for AtomEmitter<'a> {
         Err(Error::ValueNotOfExpectedType("string"))
     }
 
-    fn serialize_newtype_struct<T: ?Sized>(
+    fn serialize_newtype_struct<T>(
         self,
         _name: &'static str,
         _value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(Error::ValueNotOfExpectedType("string"))
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
@@ -582,7 +582,7 @@ impl<'a> ser::Serializer for AtomEmitter<'a> {
         _value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(Error::ValueNotOfExpectedType("string"))
     }
@@ -647,9 +647,9 @@ impl<'a, C: QueryableContextType> ser::SerializeSeq for SerializeSeq<'a, C> {
 
     type Error = Error;
 
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         if let Some((head, tail)) = attempt_opt(self.context.unify_list_functor(&self.term))? {
             let inner_serializer =
@@ -680,9 +680,9 @@ impl<'a, C: QueryableContextType> ser::SerializeTuple for SerializeTuple<'a, C> 
 
     type Error = Error;
 
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         self.len -= 1;
         if self.len == 0 {
@@ -722,9 +722,9 @@ pub struct SerializeNamedTuple<'a, C: QueryableContextType> {
 }
 
 impl<'a, C: QueryableContextType> SerializeNamedTuple<'a, C> {
-    fn serialize_field_impl<T: ?Sized>(&mut self, value: &T) -> Result<(), Error>
+    fn serialize_field_impl<T>(&mut self, value: &T) -> Result<(), Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         self.pos += 1;
 
@@ -745,9 +745,9 @@ impl<'a, C: QueryableContextType> ser::SerializeTupleStruct for SerializeNamedTu
 
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         self.serialize_field_impl(value)
     }
@@ -762,9 +762,9 @@ impl<'a, C: QueryableContextType> ser::SerializeTupleVariant for SerializeNamedT
 
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         self.serialize_field_impl(value)
     }
@@ -813,9 +813,9 @@ impl<'a, C: QueryableContextType> ser::SerializeMap for SerializeMap<'a, C> {
 
     type Error = Error;
 
-    fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<(), Self::Error>
+    fn serialize_key<T>(&mut self, key: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         let serializer = KeyEmitter {
             key: &mut self.last_key,
@@ -825,9 +825,9 @@ impl<'a, C: QueryableContextType> ser::SerializeMap for SerializeMap<'a, C> {
         key.serialize(serializer)
     }
 
-    fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_value<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         let val_term = self.context.new_term_ref();
         let serializer =
@@ -854,13 +854,13 @@ impl<'a, C: QueryableContextType> ser::SerializeStruct for SerializeMap<'a, C> {
 
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(
+    fn serialize_field<T>(
         &mut self,
         key: &'static str,
         value: &T,
     ) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         let value_term = self.context.new_term_ref();
         let serializer = Serializer::new_with_config(
@@ -887,13 +887,13 @@ impl<'a, C: QueryableContextType> ser::SerializeStructVariant for SerializeMap<'
 
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(
+    fn serialize_field<T>(
         &mut self,
         key: &'static str,
         value: &T,
     ) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         let value_term = self.context.new_term_ref();
         let serializer = Serializer::new_with_config(
@@ -1048,9 +1048,9 @@ impl<'a> ser::Serializer for KeyEmitter<'a> {
         Err(Error::ValueNotOfExpectedType("key"))
     }
 
-    fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<Self::Ok, Self::Error>
+    fn serialize_some<T>(self, _value: &T) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(Error::ValueNotOfExpectedType("key"))
     }
@@ -1072,13 +1072,13 @@ impl<'a> ser::Serializer for KeyEmitter<'a> {
         Err(Error::ValueNotOfExpectedType("key"))
     }
 
-    fn serialize_newtype_struct<T: ?Sized>(
+    fn serialize_newtype_struct<T>(
         mut self,
         name: &'static str,
         value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         // could be an atom!
         if name == ATOM_STRUCT_NAME {
@@ -1089,7 +1089,7 @@ impl<'a> ser::Serializer for KeyEmitter<'a> {
         }
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
@@ -1097,7 +1097,7 @@ impl<'a> ser::Serializer for KeyEmitter<'a> {
         _value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(Error::ValueNotOfExpectedType("key"))
     }

--- a/swipl/src/text.rs
+++ b/swipl/src/text.rs
@@ -1,5 +1,6 @@
 //! Support for easy text extraction from prolog.
 use crate::fli;
+use crate::fli::FliSuccess;
 use crate::term::*;
 use crate::term_getable;
 
@@ -41,7 +42,7 @@ term_getable! {
                                                  flags) };
 
 
-        if result == 0 {
+        if !result.is_success() {
             None
         }
         else {


### PR DESCRIPTION
# Fix clippy warnings across swipl-rs

Ran `cargo clippy --all-features -- -Dwarnings` and it was not happy. This PR addresses all reported issues so clippy passes cleanly. Most changes are mechanical, but a few deserve a second look in the PR to swipl-rs.

## Changes

Touched 15 files, net -10 lines. Roughly grouped:

**Lifetime cleanup** — the bulk of it. Elided unnecessary explicit lifetimes in `callable.rs`, `dict.rs`, `atom.rs`. Added `<'_>` annotations where clippy flagged hidden lifetimes in `context.rs` (15 spots), `engine.rs`, `atom.rs`. Straightforward stuff, though I may have missed a subtlety somewhere in the context machinery worst case. I think these should be good.

**Bound consolidation in `term/ser.rs`** — 18 serde trait method signatures had `T: ?Sized` inline and `T: Serialize` in the where clause. `?Sized` moved into the where clause so bounds live in one place. Purely cosmetic and per clippy.

**`init.rs` transmutes** — added type annotations to the two lifetime-extending transmutes so the coercion is explicit. The function pointer transmute for `pl_function_t` keeps the `transmute` (not a pointer cast) with an `#[allow]` to preserve swipl 9 + 10 compatibility. Not 100% sure this is the cleanest approach but it works for both versions.

**Smaller fixes:**
- `predicate.rs` — `#[allow(dead_code)]` on the trait rather than removing `generate_frontend` (unsure why it's there though)
- `blob.rs` (macros) — `name.len()` instead of `name.as_bytes().len()`
- `lib.rs` (macros) — doc list indentation
- `fli/lib.rs` — `#[allow(wrong_self_convention)]` on `FliSuccess` since by-value self is intentional for Copy types
- `atom.rs` — `Display` impl instead of direct `ToString`
- `atom.rs`, `term/mod.rs` — `.unwrap_or_default()` replacing verbose match blocks
- `blob.rs` — `std::ptr::eq` for raw pointer comparison
- `stream.rs` — `io::Error::other()` shorthand
- `swipl-module-example` — removed a needless borrow

## Not entirely confident about

- The `context.rs` hidden lifetime annotations are extensive. They should be correct since clippy specifically asked for them, but the context lifetime model in this crate is intricate.
- The `init.rs` transmute allow-lint tradeoff. It compiles and works for swipl 10 and should work for 9, but I haven't verified on a swipl 9 build yet.

## Verification

`cargo clippy --all-features -- -Dwarnings` exits 0. `make dev` in terminusdb builds successfully against these changes.

TerminusDB tests:
* All TerminusDB unit tests pass with swipl 10.0.0 with the TerminusDB Swipl 10 PR and these changes
* All TerminusDB integration tests also pass with swipl 10.0.0
* Built TerminusDB containers including the unit tests with these changes:
  * `make docker-debug SWIPL_VERSION=9.2.9 SKIP_TESTS=false`
  * `make docker-debug SWIPL_VERSION=10.0.0 SKIP_TESTS=false`